### PR TITLE
chore: type Post model and blog page

### DIFF
--- a/src/app/blog/[id]/page.tsx
+++ b/src/app/blog/[id]/page.tsx
@@ -1,5 +1,5 @@
 import connect from '@/lib/mongodb';
-import Post from '@/models/Post';
+import Post, { type PostDoc } from '@/models/Post';
 import { notFound } from 'next/navigation';
 
 export default async function PostPage({
@@ -10,8 +10,10 @@ export default async function PostPage({
     const { id } = await params;
 
     await connect();
-    const post = await Post.findById(id).populate('gallery').lean();
-    if (!post) return notFound();
+    const post: PostDoc | null = await Post.findById(id)
+        .populate('gallery')
+        .lean();
+    if (!post || Array.isArray(post)) return notFound();
 
     return (
         <div className="p-4">

--- a/src/models/Post.ts
+++ b/src/models/Post.ts
@@ -1,6 +1,13 @@
-import { Schema, model, models } from 'mongoose';
+import { Schema, model, models, type ObjectId } from 'mongoose';
 
-const PostSchema = new Schema(
+export interface PostDoc {
+  _id: string;
+  title: string;
+  content: string;
+  gallery?: ObjectId;
+}
+
+const PostSchema = new Schema<PostDoc>(
   {
     title: { type: String, required: true },
     content: { type: String, required: true },
@@ -9,4 +16,4 @@ const PostSchema = new Schema(
   { timestamps: true }
 );
 
-export default models.Post || model('Post', PostSchema);
+export default models.Post || model<PostDoc>('Post', PostSchema);


### PR DESCRIPTION
## Summary
- add `PostDoc` interface and type Post schema/model with it
- query post with `PostDoc` in blog page and guard against arrays

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689efe2b83f883319e034c427018c8bb