### PR TITLE
refactor: destructure params directly in PostPage

### DIFF
--- a/src/app/blog/[id]/page.tsx
+++ b/src/app/blog/[id]/page.tsx
@@ -2,12 +2,8 @@ import connect from '@/lib/mongodb';
 import Post from '@/models/Post';
 import { notFound } from 'next/navigation';
 
-export default async function PostPage({
-                                           params,
-                                       }: {
-    params: Promise<{ id: string }>;
-}) {
-    const { id } = await params;
+export default async function PostPage({ params }: { params: { id: string } }) {
+    const { id } = params;
 
     await connect();
     const post = await Post.findById(id).populate('gallery').lean();


### PR DESCRIPTION
## Summary
- simplify PostPage by accepting params directly instead of a Promise
- remove unnecessary await when extracting `id`

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689efe2c7ed08331a6d2ad6625c4a4c9