### PR TITLE
fix: adapt blog page params type for Next.js 15

### DIFF
--- a/src/app/blog/[id]/page.tsx
+++ b/src/app/blog/[id]/page.tsx
@@ -2,8 +2,8 @@ import connect from '@/lib/mongodb';
 import Post, { type PostDoc } from '@/models/Post';
 import { notFound } from 'next/navigation';
 
-export default async function PostPage({ params }: { params: { id: string } }) {
-    const { id } = params;
+export default async function PostPage({ params }: { params: Promise<{ id: string }> }) {
+    const { id } = await params;
 
     await connect();
     const post: PostDoc | null = await Post.findById(id)


### PR DESCRIPTION
## Summary
- fix PostPage params to Promise to satisfy Next.js 15 PageProps

## Testing
- `npm test`
- `npm run lint`
- `npm run build` *(fails: failed to fetch font file from Google Fonts)*

------
https://chatgpt.com/codex/tasks/task_e_689f42b912448331ad1e6a01a2514c10