### PR TITLE
Protect family galleries with Google login and admin approval

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "blog",
       "version": "0.1.0",
       "dependencies": {
+        "@supabase/auth-helpers-nextjs": "^0.10.0",
         "@supabase/supabase-js": "^2.53.0",
         "bcryptjs": "^3.0.2",
         "clsx": "^2.1.1",
@@ -1371,6 +1372,33 @@
       "resolved": "https://registry.npmjs.org/@rushstack/eslint-patch/-/eslint-patch-1.12.0.tgz",
       "integrity": "sha512-5EwMtOqvJMMa3HbmxLlF74e+3/HhwBTMcvt3nqVJgGCozO6hzIPOBlwm8mGVNR9SN2IJpxSnlxczyDjcn7qIyw==",
       "dev": true
+    },
+    "node_modules/@supabase/auth-helpers-nextjs": {
+      "version": "0.10.0",
+      "resolved": "https://registry.npmjs.org/@supabase/auth-helpers-nextjs/-/auth-helpers-nextjs-0.10.0.tgz",
+      "integrity": "sha512-2dfOGsM4yZt0oS4TPiE7bD4vf7EVz7NRz/IJrV6vLg0GP7sMUx8wndv2euLGq4BjN9lUCpu6DG/uCC8j+ylwPg==",
+      "deprecated": "This package is now deprecated - please use the @supabase/ssr package instead.",
+      "license": "MIT",
+      "dependencies": {
+        "@supabase/auth-helpers-shared": "0.7.0",
+        "set-cookie-parser": "^2.6.0"
+      },
+      "peerDependencies": {
+        "@supabase/supabase-js": "^2.39.8"
+      }
+    },
+    "node_modules/@supabase/auth-helpers-shared": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/@supabase/auth-helpers-shared/-/auth-helpers-shared-0.7.0.tgz",
+      "integrity": "sha512-FBFf2ei2R7QC+B/5wWkthMha8Ca2bWHAndN+syfuEUUfufv4mLcAgBCcgNg5nJR8L0gZfyuaxgubtOc9aW3Cpg==",
+      "deprecated": "This package is now deprecated - please use the @supabase/ssr package instead.",
+      "license": "MIT",
+      "dependencies": {
+        "jose": "^4.14.4"
+      },
+      "peerDependencies": {
+        "@supabase/supabase-js": "^2.39.8"
+      }
     },
     "node_modules/@supabase/auth-js": {
       "version": "2.71.1",
@@ -4518,6 +4546,15 @@
         "jiti": "lib/jiti-cli.mjs"
       }
     },
+    "node_modules/jose": {
+      "version": "4.15.9",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-4.15.9.tgz",
+      "integrity": "sha512-1vUQX+IdDMVPj4k8kOxgUqlcK518yluMuGZwqlr44FS1ppZB/5GWh4rZG89erpOBOJjU/OBsnCVFfapsRz6nEA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
+      }
+    },
     "node_modules/js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -5760,6 +5797,12 @@
       "engines": {
         "node": ">=10"
       }
+    },
+    "node_modules/set-cookie-parser": {
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.7.1.tgz",
+      "integrity": "sha512-IOc8uWeOZgnb3ptbCURJWNjWUPcO3ZnTTdzsurqERrP6nPyv+paC55vJM0LpOlT2ne+Ix+9+CRG1MNLlyZ4GjQ==",
+      "license": "MIT"
     },
     "node_modules/set-function-length": {
       "version": "1.2.2",

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "test": "tsx --test test/basic.test.ts test/posts.api.test.ts"
   },
   "dependencies": {
+    "@supabase/auth-helpers-nextjs": "^0.10.0",
     "@supabase/supabase-js": "^2.53.0",
     "bcryptjs": "^3.0.2",
     "clsx": "^2.1.1",

--- a/src/app/admin/users/page.tsx
+++ b/src/app/admin/users/page.tsx
@@ -1,0 +1,104 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { Button } from "@/components/ui/Button";
+import { Card } from "@/components/ui/Card";
+
+interface FamilyUser {
+  _id: string;
+  email: string;
+  name?: string;
+  status: string;
+}
+
+export default function UserManagementPage() {
+  const [pending, setPending] = useState<FamilyUser[]>([]);
+  const [search, setSearch] = useState("");
+  const [results, setResults] = useState<FamilyUser[]>([]);
+
+  useEffect(() => {
+    fetch("/api/users?status=pending").then((r) => r.json()).then(setPending);
+  }, []);
+
+  const doSearch = async (e: React.FormEvent) => {
+    e.preventDefault();
+    const res = await fetch(`/api/users?q=${encodeURIComponent(search)}`);
+    setResults(await res.json());
+  };
+
+  const update = async (id: string, action: "approve" | "block") => {
+    await fetch("/api/users", {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ id, action }),
+    });
+    setPending((p) => p.filter((u) => u._id !== id));
+    setResults((r) =>
+      r.map((u) => (u._id === id ? { ...u, status: action === "approve" ? "approved" : "blocked" } : u))
+    );
+  };
+
+  return (
+    <div className="space-y-6">
+      <div>
+        <h1 className="retro-title mb-2">Pending Requests</h1>
+        {pending.length === 0 ? (
+          <p className="text-sm text-[var(--subt)]">No pending requests.</p>
+        ) : (
+          <div className="space-y-2">
+            {pending.map((u) => (
+              <Card key={u._id} className="p-3 flex items-center justify-between">
+                <div>
+                  <div className="font-medium">{u.name || u.email}</div>
+                  <div className="text-xs text-[var(--subt)]">{u.email}</div>
+                </div>
+                <div className="space-x-2">
+                  <Button onClick={() => update(u._id, "approve")} variant="primary">
+                    Approve
+                  </Button>
+                  <Button onClick={() => update(u._id, "block")}>Block</Button>
+                </div>
+              </Card>
+            ))}
+          </div>
+        )}
+      </div>
+      <div>
+        <h2 className="retro-title mb-2">Search Users</h2>
+        <form onSubmit={doSearch} className="mb-4 flex gap-2">
+          <input
+            value={search}
+            onChange={(e) => setSearch(e.target.value)}
+            className="retro-input flex-grow"
+            placeholder="Email or name"
+          />
+          <Button type="submit">Search</Button>
+        </form>
+        {results.length > 0 && (
+          <div className="space-y-2">
+            {results.map((u) => (
+              <Card key={u._id} className="p-3 flex items-center justify-between">
+                <div>
+                  <div className="font-medium">{u.name || u.email}</div>
+                  <div className="text-xs text-[var(--subt)]">
+                    {u.email} – {u.status}
+                  </div>
+                </div>
+                <div className="space-x-2">
+                  {u.status !== "approved" && (
+                    <Button onClick={() => update(u._id, "approve")} variant="primary">
+                      Approve
+                    </Button>
+                  )}
+                  {u.status !== "blocked" && (
+                    <Button onClick={() => update(u._id, "block")}>Block</Button>
+                  )}
+                </div>
+              </Card>
+            ))}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/app/api/users/route.ts
+++ b/src/app/api/users/route.ts
@@ -1,0 +1,33 @@
+import { NextResponse } from 'next/server';
+import connect from '@/lib/mongodb';
+import FamilyUser from '@/models/FamilyUser';
+
+export async function GET(req: Request) {
+  await connect();
+  const { searchParams } = new URL(req.url);
+  const q = searchParams.get('q')?.trim();
+  const status = searchParams.get('status')?.trim();
+
+  const criteria: Record<string, unknown> = {};
+  if (status) criteria.status = status;
+  if (q) {
+    criteria.$or = [
+      { email: { $regex: q, $options: 'i' } },
+      { name: { $regex: q, $options: 'i' } },
+    ];
+  }
+
+  const users = await FamilyUser.find(criteria).sort({ createdAt: -1 }).limit(100).lean();
+  return NextResponse.json(users);
+}
+
+export async function PATCH(req: Request) {
+  await connect();
+  const { id, action } = await req.json();
+  const status = action === 'approve' ? 'approved' : action === 'block' ? 'blocked' : null;
+  if (!status) {
+    return NextResponse.json({ error: 'invalid action' }, { status: 400 });
+  }
+  const user = await FamilyUser.findByIdAndUpdate(id, { status }, { new: true }).lean();
+  return NextResponse.json(user);
+}

--- a/src/app/family/page.tsx
+++ b/src/app/family/page.tsx
@@ -1,10 +1,16 @@
 import Link from "next/link";
+import { cookies } from "next/headers";
+import { createServerComponentClient } from "@supabase/auth-helpers-nextjs";
 import connect from "@/lib/mongodb";
 import Gallery from "@/models/Gallery";
 import Tag from "@/models/Tag";
+import FamilyUser from "@/models/FamilyUser";
 import "@/models/Tag";
 import { Card } from "@/components/ui/Card";
+import FamilyLogin from "@/components/FamilyLogin";
 import { Types } from "mongoose";
+
+export const dynamic = "force-dynamic";
 
 type SearchParams = Promise<Record<string, string | string[] | undefined>>;
 type LeanTag = { _id: Types.ObjectId; name: string; color?: string };
@@ -34,8 +40,43 @@ function formatEventDate(m?: number, y?: number) {
 }
 
 export default async function FamilyPage({ searchParams }: { searchParams: SearchParams }) {
-    const sp = await searchParams;
+    const supabase = createServerComponentClient({ cookies });
+    const {
+        data: { session },
+    } = await supabase.auth.getSession();
+    if (!session) {
+        return <FamilyLogin />;
+    }
+
     await connect();
+
+    const dbUser = await FamilyUser.findOneAndUpdate(
+        { email: session.user.email },
+        {
+            $setOnInsert: { name: session.user.user_metadata?.full_name || session.user.email },
+        },
+        { upsert: true, new: true }
+    ).lean();
+
+    if (dbUser.status === "pending") {
+        return (
+            <div className="space-y-4">
+                <h1 className="retro-title">Family</h1>
+                <div className="text-sm text-[var(--subt)]">Your access request is pending approval.</div>
+            </div>
+        );
+    }
+
+    if (dbUser.status === "blocked") {
+        return (
+            <div className="space-y-4">
+                <h1 className="retro-title">Family</h1>
+                <div className="text-sm text-[var(--subt)]">Your access has been blocked.</div>
+            </div>
+        );
+    }
+
+    const sp = await searchParams;
 
     const familyTag = await Tag.findOne({ name: /^family$/i }).select("_id name").lean<{ _id: Types.ObjectId; name: string } | null>();
     const familyId = familyTag?._id;
@@ -56,10 +97,10 @@ export default async function FamilyPage({ searchParams }: { searchParams: Searc
     const validMonth = Number.isInteger(m) && m >= 1 && m <= 12 ? m : undefined;
     const validYear = Number.isInteger(y) && y >= 1900 && y <= 3000 ? y : undefined;
 
-    const and: any[] = [{ tags: familyId }];
-    if (validMonth) and.push({ eventMonth: validMonth });
-    if (validYear) and.push({ eventYear: validYear });
-    const criteria = { $and: and };
+    const filters: Record<string, unknown>[] = [{ tags: familyId }];
+    if (validMonth) filters.push({ eventMonth: validMonth });
+    if (validYear) filters.push({ eventYear: validYear });
+    const criteria = { $and: filters };
 
     // Distinct years present (within family)
     const years = (await Gallery.distinct("eventYear", { tags: familyId }))

--- a/src/components/FamilyLogin.tsx
+++ b/src/components/FamilyLogin.tsx
@@ -1,0 +1,31 @@
+"use client";
+
+import { supabase } from "@/lib/supabaseClient";
+import { Button } from "@/components/ui/Button";
+import { Card } from "@/components/ui/Card";
+
+export default function FamilyLogin() {
+  return (
+    <div className="p-6 max-w-lg mx-auto">
+      <Card className="space-y-4 p-4">
+        <h1 className="retro-title">Family</h1>
+        <p className="text-sm text-[var(--subt)]">Sign in to view family galleries.</p>
+        <Button
+          onClick={() =>
+            supabase.auth.signInWithOAuth({
+              provider: "google",
+              options: {
+                redirectTo:
+                  typeof window !== "undefined" ? `${window.location.origin}/family` : undefined,
+                queryParams: { access_type: "offline", prompt: "consent" },
+              },
+            })
+          }
+          variant="primary"
+        >
+          Sign in with Google
+        </Button>
+      </Card>
+    </div>
+  );
+}

--- a/src/components/admin/AdminShell.tsx
+++ b/src/components/admin/AdminShell.tsx
@@ -15,6 +15,7 @@ const NAV = [
     { href: "/admin/galleries/new", label: "Create Gallery" },
     { href: "/admin/galleries", label: "Manage Galleries" },
     { href: "/admin/tags", label: "Manage Tags" },
+    { href: "/admin/users", label: "User Management" },
 ];
 
 export default function AdminShell({ children }: { children: React.ReactNode }) {

--- a/src/models/FamilyUser.ts
+++ b/src/models/FamilyUser.ts
@@ -1,0 +1,23 @@
+import { Schema, model, models } from 'mongoose';
+
+export interface FamilyUserDoc {
+  _id: string;
+  email: string;
+  name?: string;
+  status: 'pending' | 'approved' | 'blocked';
+}
+
+const FamilyUserSchema = new Schema<FamilyUserDoc>(
+  {
+    email: { type: String, required: true, unique: true },
+    name: { type: String },
+    status: {
+      type: String,
+      enum: ['pending', 'approved', 'blocked'],
+      default: 'pending',
+    },
+  },
+  { timestamps: true }
+);
+
+export default models.FamilyUser || model<FamilyUserDoc>('FamilyUser', FamilyUserSchema);


### PR DESCRIPTION
## Summary
- Require Google sign-in before accessing the Family section and track users in MongoDB
- Add admin user-management page to approve or block Family access requests
- Provide `/api/users` endpoint for listing and updating user access status

## Testing
- `npm test`
- `npm run lint` *(fails: Unexpected any and other lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_68a63a324cc08331af038c19a9bcb678