### PR TITLE
feat: add gallery previews and post thumbnails

### DIFF
--- a/src/app/admin/galleries/new/page.tsx
+++ b/src/app/admin/galleries/new/page.tsx
@@ -21,6 +21,7 @@ export default function CreateGalleryPage() {
     const [name, setName] = useState("");
     const [images, setImages] = useState("");
     const [password, setPassword] = useState("");
+    const [previews, setPreviews] = useState<string[]>([]);
 
     const [tags, setTags] = useState<string[]>([]);
     const [tagChoice, setTagChoice] = useState("");
@@ -60,6 +61,7 @@ export default function CreateGalleryPage() {
         });
         setName(""); setImages(""); setPassword(""); setTags([]);
         setEventMonth(""); setEventYear("");
+        setPreviews([]);
         alert("Gallery created");
     };
 
@@ -70,14 +72,23 @@ export default function CreateGalleryPage() {
                 <form onSubmit={submit} className="grid gap-2">
                     <Input placeholder="Name" value={name} onChange={(e) => setName(e.target.value)} />
                     <Uploader
-                        onUploaded={(urls) =>
+                        onUploaded={(urls) => {
+                            setPreviews((prev) => [...prev, ...urls]);
                             setImages((prev) =>
                                 [prev, urls.join(", ")]
                                     .filter(Boolean)
                                     .join(", ")
-                            )
-                        }
+                            );
+                        }}
                     />
+                    {previews.length > 0 && (
+                        <div className="flex flex-wrap gap-2">
+                            {previews.map((src, i) => (
+                                // eslint-disable-next-line @next/next/no-img-element
+                                <img key={i} src={src} alt="preview" className="w-24 h-24 object-cover" />
+                            ))}
+                        </div>
+                    )}
                     <Input type="password" placeholder="Password (optional)" value={password} onChange={(e) => setPassword(e.target.value)} />
 
                     {/* Month / Year */}

--- a/src/app/blog/[id]/page.tsx
+++ b/src/app/blog/[id]/page.tsx
@@ -9,7 +9,7 @@ import { Card } from "@/components/ui/Card";
 
 type Params = Promise<{ id: string }>;
 type LeanTag = { _id: Types.ObjectId; name: string; color?: string };
-type LeanGallery = { _id: Types.ObjectId; name: string };
+type LeanGallery = { _id: Types.ObjectId; name: string; images?: string[] };
 type LeanPost = {
     _id: Types.ObjectId;
     title: string;
@@ -68,7 +68,7 @@ export default async function PostPage({ params }: { params: Params }) {
 
     const post = await Post.findById(id)
         .select("title content gallery tags createdAt")
-        .populate("gallery", "name")
+        .populate("gallery", "name images")
         .populate("tags", "name color")
         .lean<LeanPost>();
 
@@ -79,6 +79,7 @@ export default async function PostPage({ params }: { params: Params }) {
         post.gallery && typeof post.gallery === "object" ? (post.gallery as LeanGallery) : null;
     const galleryId = gallery?._id?.toString?.();
     const galleryName = gallery?.name ?? null;
+    const galleryImages = Array.isArray(gallery?.images) ? gallery.images : [];
 
     // tags normalized
     const tags =
@@ -114,6 +115,17 @@ export default async function PostPage({ params }: { params: Params }) {
                     >
                         {post.title}
                     </h1>
+
+                    {galleryId && galleryImages.length > 0 && (
+                        <Link href={`/galleries/${galleryId}`} className="mt-2 block">
+                            <div className="flex gap-2">
+                                {galleryImages.slice(0, 4).map((src, i) => (
+                                    // eslint-disable-next-line @next/next/no-img-element
+                                    <img key={i} src={src} alt="gallery preview" className="w-16 h-16 object-cover border" />
+                                ))}
+                            </div>
+                        </Link>
+                    )}
 
                     <div className="mt-2 flex flex-wrap items-center gap-3 text-xs text-[var(--subt)]">
                         {created && <span className="retro-label">{created}</span>}


### PR DESCRIPTION
## Summary
- show selected image previews when creating a gallery
- display miniature gallery thumbnails on posts when a gallery is linked

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68acbc2747ec833198327c0a5ee6bbdb