### PR TITLE
Handle promise-based params in post route handlers

### DIFF
--- a/src/app/api/posts/[id]/route.ts
+++ b/src/app/api/posts/[id]/route.ts
@@ -2,23 +2,25 @@ import { NextResponse } from 'next/server';
 import connect from '@/lib/mongodb';
 import Post from '@/models/Post';
 
-type Ctx = { params: { id: string } };
+type Ctx = { params: Promise<{ id: string }> };
 
 export async function PUT(req: Request, { params }: Ctx) {
     await connect();
+    const { id } = await params;
     const body = await req.json();
     const update: any = {};
     if (typeof body.title === 'string') update.title = body.title;
     if (typeof body.content === 'string') update.content = body.content;
     if ('gallery' in body) update.gallery = body.gallery || null;
     if (Array.isArray(body.tags)) update.tags = body.tags;
-    const post = await Post.findByIdAndUpdate(params.id, { $set: update }, { new: true });
+    const post = await Post.findByIdAndUpdate(id, { $set: update }, { new: true });
     return NextResponse.json(post);
 }
 
 export async function DELETE(_req: Request, { params }: Ctx) {
     await connect();
-    await Post.findByIdAndDelete(params.id);
+    const { id } = await params;
+    await Post.findByIdAndDelete(id);
     return NextResponse.json({ ok: true });
 }
 


### PR DESCRIPTION
## Summary
- switch API route context params to a Promise
- await and destructure id in PUT and DELETE handlers

## Testing
- `npm test`
- `npm run dev`

------
https://chatgpt.com/codex/tasks/task_e_68acbffd973c83318abf6912a330f228