### PR TITLE
Avoid clearing gallery images when unchanged

### DIFF
--- a/src/app/api/galleries/[id]/route.ts
+++ b/src/app/api/galleries/[id]/route.ts
@@ -13,7 +13,8 @@ export async function PUT(req: Request, { params }: Ctx) {
     const unset: any = {};
 
     if (typeof body.name === 'string') set.name = body.name;
-    if (Array.isArray(body.images)) set.images = body.images;
+    // Only update images when a non-empty array is provided to avoid accidental clears
+    if (Array.isArray(body.images) && body.images.length > 0) set.images = body.images;
     if (Array.isArray(body.tags)) set.tags = body.tags;
 
     if (typeof body.password === 'string' && body.password.length > 0) {


### PR DESCRIPTION
## Summary
- Guard gallery update endpoint from wiping images by only applying non-empty image arrays

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68acc307957083318fe32bf2b958b3db