### PR TITLE
Implement file upload API and integrate gallery uploader

### DIFF
--- a/src/app/admin/galleries/new/page.tsx
+++ b/src/app/admin/galleries/new/page.tsx
@@ -19,7 +19,7 @@ const MONTHS = [
 export default function CreateGalleryPage() {
     const [allTags, setAllTags] = useState<TagRec[]>([]);
     const [name, setName] = useState("");
-    const [images, setImages] = useState("");
+    const [images, setImages] = useState<string[]>([]);
     const [password, setPassword] = useState("");
     const [previews, setPreviews] = useState<string[]>([]);
 
@@ -52,14 +52,14 @@ export default function CreateGalleryPage() {
             headers: { "Content-Type": "application/json" },
             body: JSON.stringify({
                 name,
-                images: images.split(",").map((s) => s.trim()).filter(Boolean),
+                images,
                 password: password || undefined,
                 tags,
                 eventMonth: eventMonth === "" ? undefined : eventMonth,
                 eventYear: eventYear === "" ? undefined : eventYear,
             }),
         });
-        setName(""); setImages(""); setPassword(""); setTags([]);
+        setName(""); setImages([]); setPassword(""); setTags([]);
         setEventMonth(""); setEventYear("");
         setPreviews([]);
         alert("Gallery created");
@@ -74,11 +74,7 @@ export default function CreateGalleryPage() {
                     <Uploader
                         onUploaded={(urls) => {
                             setPreviews((prev) => [...prev, ...urls]);
-                            setImages((prev) =>
-                                [prev, urls.join(", ")]
-                                    .filter(Boolean)
-                                    .join(", ")
-                            );
+                            setImages((prev) => [...prev, ...urls]);
                         }}
                     />
                     {previews.length > 0 && (

--- a/src/app/api/upload/route.ts
+++ b/src/app/api/upload/route.ts
@@ -1,0 +1,26 @@
+import { NextResponse } from "next/server";
+import { writeFile, mkdir } from "fs/promises";
+import path from "path";
+
+export const runtime = "nodejs";
+
+export async function POST(request: Request) {
+  const formData = await request.formData();
+  const files = formData.getAll("files");
+  const urls: string[] = [];
+
+  const uploadDir = path.join(process.cwd(), "public/uploads");
+  await mkdir(uploadDir, { recursive: true });
+
+  for (const file of files) {
+    if (typeof file === "string") continue;
+    const arrayBuffer = await file.arrayBuffer();
+    const buffer = Buffer.from(arrayBuffer);
+    const uniqueName = `${Date.now()}-${file.name}`;
+    const filePath = path.join(uploadDir, uniqueName);
+    await writeFile(filePath, buffer);
+    urls.push(`/uploads/${uniqueName}`);
+  }
+
+  return NextResponse.json({ urls });
+}

--- a/src/components/Uploader.tsx
+++ b/src/components/Uploader.tsx
@@ -8,11 +8,29 @@ interface UploaderProps {
 }
 
 export default function Uploader({ onUploaded, className }: UploaderProps) {
-  const handleChange = (e: ChangeEvent<HTMLInputElement>) => {
+  const handleChange = async (e: ChangeEvent<HTMLInputElement>) => {
     const files = Array.from(e.target.files ?? []);
-    const urls = files.map((f) => URL.createObjectURL(f));
-    if (urls.length > 0) onUploaded(urls);
-    e.target.value = "";
+    if (files.length === 0) return;
+
+    const formData = new FormData();
+    files.forEach((file) => formData.append("files", file));
+
+    try {
+      const res = await fetch("/api/upload", {
+        method: "POST",
+        body: formData,
+      });
+      if (res.ok) {
+        const data = await res.json();
+        if (Array.isArray(data.urls) && data.urls.length > 0) {
+          onUploaded(data.urls);
+        }
+      }
+    } catch (err) {
+      console.error("Upload failed", err);
+    } finally {
+      e.target.value = "";
+    }
   };
 
   return (


### PR DESCRIPTION
## Summary
- add `/api/upload` endpoint saving multipart files to `public/uploads` and returning URLs
- send selected files to new endpoint in `Uploader` component and use server URLs
- persist uploaded image URLs in gallery creation form when submitting

## Testing
- `npm test`
- `npm run lint` *(fails: Unexpected any in existing files)*
- `npx eslint src/app/api/upload/route.ts src/components/Uploader.tsx src/app/admin/galleries/new/page.tsx`

------
https://chatgpt.com/codex/tasks/task_e_68ad843c194083319233beac5be0381e