### PR TITLE
Ensure text colors match theme and show user name

### DIFF
--- a/src/app/blog/[id]/page.tsx
+++ b/src/app/blog/[id]/page.tsx
@@ -46,19 +46,13 @@ function renderWithLinks(text: string): React.ReactNode {
 }
 
 function pickTextColor(hex?: string) {
-    if (!hex || !/^#?[0-9a-f]{6}$/i.test(hex)) return "#000";
+    if (!hex || !/^#?[0-9a-f]{6}$/i.test(hex)) return "var(--text)";
     const h = hex.replace("#", "");
     const r = parseInt(h.slice(0, 2), 16) / 255;
     const g = parseInt(h.slice(2, 4), 16) / 255;
     const b = parseInt(h.slice(4, 6), 16) / 255;
     const L = 0.2126 * r + 0.7152 * g + 0.0722 * b; // luminance
     return L > 0.55 ? "#000" : "#fff";
-}
-
-function hashString(s: string) {
-    let h = 0;
-    for (let i = 0; i < s.length; i++) h = (h * 31 + s.charCodeAt(i)) | 0;
-    return Math.abs(h);
 }
 
 export default async function PostPage({ params }: { params: Params }) {
@@ -93,9 +87,6 @@ export default async function PostPage({ params }: { params: Params }) {
                 .filter(Boolean) as { id: string; name: string; color?: string }[])
             : [];
 
-    // catchy accent: prefer first tag's color; else pick from retro palette by id hash
-    const palette = ["#ff4fa3", "#2bd9ff", "#ffd166", "#4f9dff"];
-    const accentHex = tags[0]?.color || palette[hashString(id) % palette.length];
     const titleShadow = "3px 3px 0 rgba(0,0,0,.8)";
 
     const created =
@@ -109,7 +100,7 @@ export default async function PostPage({ params }: { params: Params }) {
                     <h1
                         className="post-title font-[var(--font-vt323)] leading-none tracking-tight"
                         style={{
-                            color: accentHex,
+                            color: "var(--accent)",
                             textShadow: titleShadow,
                         }}
                     >

--- a/src/app/family/page.tsx
+++ b/src/app/family/page.tsx
@@ -21,16 +21,6 @@ const MONTHS = [
     { v: 7, n: "Jul" }, { v: 8, n: "Aug" }, { v: 9, n: "Sep" },
     { v: 10, n: "Oct" }, { v: 11, n: "Nov" }, { v: 12, n: "Dec" },
 ];
-
-function pickTextColor(hex?: string) {
-    if (!hex || !/^#?[0-9a-f]{6}$/i.test(hex)) return "#000";
-    const h = hex.replace("#", "");
-    const r = parseInt(h.slice(0, 2), 16) / 255;
-    const g = parseInt(h.slice(2, 4), 16) / 255;
-    const b = parseInt(h.slice(4, 6), 16) / 255;
-    const L = 0.2126 * r + 0.7152 * g + 0.0722 * b;
-    return L > 0.55 ? "#000" : "#fff";
-}
 function formatEventDate(m?: number, y?: number) {
     const names = ["", "Jan","Feb","Mar","Apr","May","Jun","Jul","Aug","Sep","Oct","Nov","Dec"];
     if (m && y) return `${names[m]} ${y}`;

--- a/src/app/galleries/[id]/page.tsx
+++ b/src/app/galleries/[id]/page.tsx
@@ -12,7 +12,7 @@ type SearchParams = Promise<{ password?: string | string[] }>;
 type LeanTag = { _id: Types.ObjectId; name: string; color?: string };
 
 function pickTextColor(hex?: string) {
-    if (!hex || !/^#?[0-9a-f]{6}$/i.test(hex)) return "#000";
+    if (!hex || !/^#?[0-9a-f]{6}$/i.test(hex)) return "var(--text)";
     const h = hex.replace("#", "");
     const r = parseInt(h.slice(0, 2), 16) / 255;
     const g = parseInt(h.slice(2, 4), 16) / 255;
@@ -20,7 +20,6 @@ function pickTextColor(hex?: string) {
     const L = 0.2126 * r + 0.7152 * g + 0.0722 * b;
     return L > 0.55 ? "#000" : "#fff";
 }
-function hashString(s: string) { let h = 0; for (let i=0;i<s.length;i++) h = (h*31 + s.charCodeAt(i))|0; return Math.abs(h); }
 
 function formatEventDate(month?: number, year?: number) {
     const names = ["", "Jan","Feb","Mar","Apr","May","Jun","Jul","Aug","Sep","Oct","Nov","Dec"];
@@ -75,15 +74,13 @@ export default async function GalleryPage({
 
     const images: string[] = Array.isArray(gallery.images) ? gallery.images : [];
 
-    // Accent color: prefer first tag color, else palette by id hash
+    // Gather tags for badge display
     const tags =
         Array.isArray(gallery.tags)
             ? (gallery.tags
                 .map((t) => (typeof t === 'object' ? { id: t._id.toString(), name: t.name, color: t.color } : null))
                 .filter(Boolean) as { id: string; name: string; color?: string }[])
             : [];
-    const palette = ["#ff4fa3", "#2bd9ff", "#ffd166", "#4f9dff"];
-    const accentHex = tags[0]?.color || palette[hashString(id) % palette.length];
 
     return (
         <div className="p-4">
@@ -91,7 +88,7 @@ export default async function GalleryPage({
                 <header className="px-4 md:px-6 py-4 border-b" style={{ borderColor: "var(--border)" }}>
                     <h1
                         className="page-title leading-none tracking-tight"
-                        style={{ color: accentHex, textShadow: "3px 3px 0 rgba(0,0,0,.8)" }}
+                        style={{ color: "var(--accent)", textShadow: "3px 3px 0 rgba(0,0,0,.8)" }}
                     >
                         {gallery.name}
                     </h1>

--- a/src/app/galleries/page.tsx
+++ b/src/app/galleries/page.tsx
@@ -19,7 +19,7 @@ const MONTHS = [
 ];
 
 function pickTextColor(hex?: string) {
-    if (!hex || !/^#?[0-9a-f]{6}$/i.test(hex)) return "#000";
+    if (!hex || !/^#?[0-9a-f]{6}$/i.test(hex)) return "var(--text)";
     const h = hex.replace("#", "");
     const r = parseInt(h.slice(0, 2), 16) / 255;
     const g = parseInt(h.slice(2, 4), 16) / 255;

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -4,6 +4,7 @@ import "./globals.css";
 import { Inter, VT323 } from "next/font/google";
 import Link from "next/link";
 import ThemeToggle from "@/components/ThemeToggle";
+import UserName from "@/components/UserName";
 
 const inter = Inter({ subsets: ["latin"], variable: "--font-inter" });
 const vt323 = VT323({ weight: "400", subsets: ["latin"], variable: "--font-vt323" });
@@ -45,6 +46,7 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
                     <span className="retro-title ml-2">Portfolio</span>
 
                     <div className="ml-auto flex items-center gap-2">
+                        <UserName />
                         <ThemeToggle />
                     </div>
                 </nav>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -29,7 +29,7 @@ type LGallery = {
 
 function pickTextColor(hex?: string) {
     // very small helper to ensure contrast on the badge background
-    if (!hex || !/^#?[0-9a-f]{6}$/i.test(hex)) return "#000";
+    if (!hex || !/^#?[0-9a-f]{6}$/i.test(hex)) return "var(--text)";
     const h = hex.replace("#", "");
     const r = parseInt(h.slice(0, 2), 16) / 255;
     const g = parseInt(h.slice(2, 4), 16) / 255;

--- a/src/components/TopNav.tsx
+++ b/src/components/TopNav.tsx
@@ -4,6 +4,7 @@
 import Link from "next/link";
 import { usePathname, useRouter } from "next/navigation";
 import ThemeToggle from "@/components/ThemeToggle";
+import UserName from "@/components/UserName";
 
 export default function TopNav() {
     const pathname = usePathname();
@@ -30,6 +31,7 @@ export default function TopNav() {
             <span className="retro-title ml-2">Portfolio</span>
 
             <div className="ml-auto flex items-center gap-2">
+                <UserName />
                 <ThemeToggle />
             </div>
         </nav>

--- a/src/components/UserName.tsx
+++ b/src/components/UserName.tsx
@@ -1,0 +1,41 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { supabase } from "@/lib/supabaseClient";
+type Metadata = { full_name?: string };
+
+export default function UserName() {
+    const [name, setName] = useState("guest");
+
+    useEffect(() => {
+        const load = async () => {
+            const {
+                data: { user },
+            } = await supabase.auth.getUser();
+            if (user) {
+                const full = (user.user_metadata as Metadata)?.full_name;
+                setName(full || user.email || "guest");
+            }
+        };
+        load();
+
+        const {
+            data: { subscription },
+        } = supabase.auth.onAuthStateChange((_event, session) => {
+            const user = session?.user;
+            if (user) {
+                const full = (user.user_metadata as Metadata)?.full_name;
+                setName(full || user.email || "guest");
+            } else {
+                setName("guest");
+            }
+        });
+
+        return () => {
+            subscription.unsubscribe();
+        };
+    }, []);
+
+    return <span className="text-sm text-[var(--subt)]">{name}</span>;
+}
+


### PR DESCRIPTION
## Summary
- default badge text color to theme variable
- use theme accent for gallery and post titles to avoid low contrast
- show signed-in Google user name or guest in nav

## Testing
- `npm test`
- `npm run lint` *(fails: Unexpected any in existing code)*

------
https://chatgpt.com/codex/tasks/task_e_68ae115def5c83319ae35049738f8719