### PR TITLE
Enable family users to create and expand galleries

### DIFF
--- a/src/app/api/family/galleries/[id]/upload/route.ts
+++ b/src/app/api/family/galleries/[id]/upload/route.ts
@@ -1,0 +1,60 @@
+// app/api/family/galleries/[id]/upload/route.ts
+import { NextRequest, NextResponse } from "next/server";
+import { createClient } from "@/utils/supabase/server";
+import connect from "@/lib/mongodb";
+import FamilyUser from "@/models/FamilyUser";
+import Gallery from "@/models/Gallery";
+import Tag from "@/models/Tag";
+import { ensureGalleryDir, writeBufferFile, uniqueName } from "@/lib/fs-server";
+import { slugify } from "@/lib/slug";
+import { join, extname, basename } from "node:path";
+import { Types } from "mongoose";
+
+export const runtime = "nodejs";
+
+export async function POST(req: NextRequest, ctx: { params: Promise<{ id: string }> }) {
+    const { id } = await ctx.params;
+    const supabase = await createClient();
+    const { data: { user } } = await supabase.auth.getUser();
+    if (!user?.email) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+
+    await connect();
+    const dbUser = await FamilyUser.findOne({ email: user.email }).lean();
+    if (dbUser?.status !== "approved") {
+        return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+    }
+
+    const familyTag = await Tag.findOne({ name: /^family$/i }).select("_id").lean<{ _id: Types.ObjectId } | null>();
+    const g = await Gallery.findOne({ _id: id, tags: familyTag?._id });
+    if (!g) return NextResponse.json({ error: "Not found" }, { status: 404 });
+
+    if (!g.slug || typeof g.slug !== "string" || g.slug.trim() === "") {
+        const fallbackName = typeof g.name === "string" && g.name.trim() ? g.name : String(g._id);
+        g.slug = slugify(fallbackName);
+        await g.save();
+    }
+
+    const form = await req.formData();
+    const files = form.getAll("files").filter((f): f is File => f instanceof File);
+    if (!files.length) return NextResponse.json({ error: "No files" }, { status: 400 });
+
+    const dir = ensureGalleryDir(g.slug);
+    const urls: string[] = [];
+
+    for (const f of files) {
+        const ab = await f.arrayBuffer();
+        const buf = Buffer.from(ab);
+        const ext = (extname(f.name) || ".jpg").replace(".", "");
+        const base = basename(f.name, "." + ext);
+        const filename = uniqueName(base, ext);
+        const dest = join(dir, filename);
+        await writeBufferFile(dest, buf);
+        urls.push(`/galleries/${g.slug}/${filename}`);
+    }
+
+    g.images.push(...urls);
+    g.updatedAt = new Date();
+    await g.save();
+
+    return NextResponse.json({ urls }, { status: 200 });
+}

--- a/src/app/api/family/galleries/route.ts
+++ b/src/app/api/family/galleries/route.ts
@@ -1,0 +1,82 @@
+// app/api/family/galleries/route.ts
+import { NextRequest, NextResponse } from "next/server";
+import { createClient } from "@/utils/supabase/server";
+import connect from "@/lib/mongodb";
+import FamilyUser from "@/models/FamilyUser";
+import Gallery from "@/models/Gallery";
+import Tag from "@/models/Tag";
+import { ensureGalleryDir, writeBufferFile, uniqueName } from "@/lib/fs-server";
+import { slugify } from "@/lib/slug";
+import { join, extname, basename } from "node:path";
+import { Types } from "mongoose";
+
+export const runtime = "nodejs";
+
+export async function POST(req: NextRequest) {
+    try {
+        const supabase = await createClient();
+        const { data: { user } } = await supabase.auth.getUser();
+        if (!user?.email) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+
+        await connect();
+        const dbUser = await FamilyUser.findOne({ email: user.email }).lean();
+        if (dbUser?.status !== "approved") {
+            return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+        }
+
+        const ct = req.headers.get("content-type") || "";
+        if (!ct.includes("multipart/form-data")) {
+            return NextResponse.json({ error: "Send multipart/form-data" }, { status: 400 });
+        }
+
+        const form = await req.formData();
+        const name = String(form.get("name") || "").trim();
+        if (!name) return NextResponse.json({ error: "Name is required" }, { status: 400 });
+
+        const files = form.getAll("files").filter((f): f is File => f instanceof File);
+        if (files.length === 0) {
+            return NextResponse.json({ error: "No files" }, { status: 400 });
+        }
+
+        const eventMonthRaw = form.get("eventMonth");
+        const eventYearRaw = form.get("eventYear");
+
+        // Find or create the family tag
+        const familyTag = await Tag.findOneAndUpdate(
+            { name: /^family$/i },
+            { $setOnInsert: { name: "family" } },
+            { new: true, upsert: true }
+        ).lean<{ _id: Types.ObjectId }>();
+
+        const slug = slugify(name);
+        const dir = ensureGalleryDir(slug);
+        const urls: string[] = [];
+
+        for (const f of files) {
+            const ab = await f.arrayBuffer();
+            const buf = Buffer.from(ab);
+            const ext = (extname(f.name) || ".jpg").replace(".", "");
+            const base = basename(f.name, "." + ext);
+            const filename = uniqueName(base, ext);
+            const dest = join(dir, filename);
+            await writeBufferFile(dest, buf);
+            urls.push(`/galleries/${slug}/${filename}`);
+        }
+
+        const doc = await Gallery.create({
+            name,
+            slug,
+            images: urls,
+            tags: [familyTag._id],
+            eventMonth: eventMonthRaw ? Number(eventMonthRaw) : undefined,
+            eventYear: eventYearRaw ? Number(eventYearRaw) : undefined,
+            createdAt: new Date(),
+            updatedAt: new Date(),
+        });
+
+        return NextResponse.json({ _id: doc._id, name: doc.name, slug: doc.slug, images: doc.images }, { status: 201 });
+    } catch (e) {
+        console.error(e);
+        return NextResponse.json({ error: "Create failed" }, { status: 500 });
+    }
+}

--- a/src/app/family/galleries/[id]/add/Client.tsx
+++ b/src/app/family/galleries/[id]/add/Client.tsx
@@ -1,0 +1,30 @@
+"use client";
+
+import { useState } from "react";
+import { Card } from "@/components/ui/Card";
+import Uploader from "@/components/Uploader";
+
+export default function Client({ id, name, initialImages }: { id: string; name: string; initialImages: string[] }) {
+    const [images, setImages] = useState(initialImages);
+    return (
+        <div className="space-y-3">
+            <h1 className="retro-title">Add Photos – {name}</h1>
+            <Card className="space-y-2 p-4">
+                <Uploader
+                    multiple
+                    accept="image/*"
+                    to={`/api/family/galleries/${id}/upload`}
+                    onUploaded={(urls) => setImages((prev) => [...prev, ...urls])}
+                />
+                {images.length > 0 && (
+                    <div className="flex flex-wrap gap-2">
+                        {images.map((src, i) => (
+                            // eslint-disable-next-line @next/next/no-img-element
+                            <img key={i} src={src} alt="img" className="w-24 h-24 object-cover" />
+                        ))}
+                    </div>
+                )}
+            </Card>
+        </div>
+    );
+}

--- a/src/app/family/galleries/[id]/add/page.tsx
+++ b/src/app/family/galleries/[id]/add/page.tsx
@@ -1,0 +1,45 @@
+import { createClient } from "@/utils/supabase/server";
+import connect from "@/lib/mongodb";
+import FamilyUser from "@/models/FamilyUser";
+import Gallery from "@/models/Gallery";
+import Tag from "@/models/Tag";
+import FamilyLogin from "@/components/FamilyLogin";
+import { Types } from "mongoose";
+import Client from "./Client";
+
+export const dynamic = "force-dynamic";
+
+type Params = Promise<{ id: string }>;
+
+type LeanGallery = { _id: Types.ObjectId; name: string; images: string[] };
+
+export default async function AddPhotosPage({ params }: { params: Params }) {
+    const { id } = await params;
+    const supabase = await createClient();
+    const { data: { user } } = await supabase.auth.getUser();
+    if (!user?.email) return <FamilyLogin />;
+
+    await connect();
+    const dbUser = await FamilyUser.findOne({ email: user.email }).lean();
+    if (dbUser?.status !== "approved") {
+        return (
+            <div className="space-y-4">
+                <h1 className="retro-title">Family</h1>
+                <div className="text-sm text-[var(--subt)]">Your access request is pending approval.</div>
+            </div>
+        );
+    }
+
+    const familyTag = await Tag.findOne({ name: /^family$/i }).select("_id").lean<{ _id: Types.ObjectId } | null>();
+    const g = await Gallery.findOne({ _id: id, tags: familyTag?._id }).lean<LeanGallery | null>();
+    if (!g) {
+        return (
+            <div className="space-y-4">
+                <h1 className="retro-title">Family</h1>
+                <div className="text-sm text-[var(--subt)]">Gallery not found.</div>
+            </div>
+        );
+    }
+
+    return <Client id={id} name={g.name} initialImages={g.images} />;
+}

--- a/src/app/family/galleries/new/Form.tsx
+++ b/src/app/family/galleries/new/Form.tsx
@@ -1,0 +1,67 @@
+"use client";
+
+import { useState } from "react";
+import { Card } from "@/components/ui/Card";
+import { Button } from "@/components/ui/Button";
+import { Input } from "@/components/ui/Input";
+
+export default function Form() {
+    const [name, setName] = useState("");
+    const [files, setFiles] = useState<FileList | null>(null);
+    const [previews, setPreviews] = useState<string[]>([]);
+    const [busy, setBusy] = useState(false);
+
+    const onPickFiles: React.ChangeEventHandler<HTMLInputElement> = (e) => {
+        const fs = e.target.files;
+        setFiles(fs);
+        if (fs && fs.length) {
+            const urls = Array.from(fs).map((f) => URL.createObjectURL(f));
+            setPreviews(urls);
+        }
+    };
+
+    const submit: React.FormEventHandler = async (e) => {
+        e.preventDefault();
+        setBusy(true);
+        try {
+            const form = new FormData();
+            form.set("name", name);
+            if (files) Array.from(files).forEach((f) => form.append("files", f));
+            const res = await fetch("/api/family/galleries", { method: "POST", body: form });
+            const data = await res.json();
+            if (!res.ok) throw new Error(data?.error || "Create failed");
+            setName("");
+            setFiles(null);
+            setPreviews([]);
+            alert("Gallery created");
+        } catch (err) {
+            console.error(err);
+            alert(err instanceof Error ? err.message : String(err));
+        } finally {
+            setBusy(false);
+        }
+    };
+
+    return (
+        <div className="space-y-3">
+            <h1 className="retro-title">New Family Gallery</h1>
+            <Card className="space-y-2">
+                <form onSubmit={submit} className="grid gap-2">
+                    <Input placeholder="Name" value={name} onChange={(e) => setName(e.target.value)} />
+                    <input type="file" multiple accept="image/*" onChange={onPickFiles} />
+                    {previews.length > 0 && (
+                        <div className="flex flex-wrap gap-2">
+                            {previews.map((src, i) => (
+                                // eslint-disable-next-line @next/next/no-img-element
+                                <img key={i} src={src} alt="preview" className="w-24 h-24 object-cover" />
+                            ))}
+                        </div>
+                    )}
+                    <Button variant="primary" type="submit" disabled={busy}>
+                        {busy ? "Saving…" : "Save Gallery"}
+                    </Button>
+                </form>
+            </Card>
+        </div>
+    );
+}

--- a/src/app/family/galleries/new/page.tsx
+++ b/src/app/family/galleries/new/page.tsx
@@ -1,0 +1,26 @@
+import { createClient } from "@/utils/supabase/server";
+import connect from "@/lib/mongodb";
+import FamilyUser from "@/models/FamilyUser";
+import FamilyLogin from "@/components/FamilyLogin";
+import Form from "./Form";
+
+export const dynamic = "force-dynamic";
+
+export default async function NewFamilyGallery() {
+    const supabase = await createClient();
+    const { data: { user } } = await supabase.auth.getUser();
+    if (!user?.email) return <FamilyLogin />;
+
+    await connect();
+    const dbUser = await FamilyUser.findOne({ email: user.email }).lean();
+    if (dbUser?.status !== "approved") {
+        return (
+            <div className="space-y-4">
+                <h1 className="retro-title">Family</h1>
+                <div className="text-sm text-[var(--subt)]">Your access request is pending approval.</div>
+            </div>
+        );
+    }
+
+    return <Form />;
+}

--- a/src/app/family/page.tsx
+++ b/src/app/family/page.tsx
@@ -44,7 +44,7 @@ export default async function FamilyPage({ searchParams }: { searchParams: Searc
         { email: user.email },
         {
             $setOnInsert: {
-                name: (user.user_metadata as any)?.full_name || user.email,
+                name: (user.user_metadata as { full_name?: string } | null)?.full_name || user.email,
                 status: "pending",
             },
         },
@@ -125,6 +125,7 @@ export default async function FamilyPage({ searchParams }: { searchParams: Searc
     return (
         <div className="space-y-4">
             <h1 className="retro-title">Family</h1>
+            <Link href="/family/galleries/new" className="retro-btn">New Gallery</Link>
 
             {/* Filter bar */}
             <form method="GET" className="grid gap-2 md:grid-cols-[150px_150px_auto_auto] items-end">
@@ -156,24 +157,29 @@ export default async function FamilyPage({ searchParams }: { searchParams: Searc
             ) : (
                 <div className="grid gap-3 grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4">
                     {cards.map((g) => (
-                        <Link key={g.id} href={g.href} className="no-underline">
-                            <Card className="p-0 overflow-hidden">
-                                <div className="relative aspect-[4/3] bg-[var(--muted)]">
-                                    {g.thumb ? (
-                                        // eslint-disable-next-line @next/next/no-img-element
-                                        <img src={g.thumb} alt={g.name} className="w-full h-full object-cover" loading="lazy" />
-                                    ) : (
-                                        <div className="w-full h-full" style={{ background: "repeating-linear-gradient(45deg, var(--muted) 0 8px, rgba(0,0,0,.05) 8px 16px)" }} />
-                                    )}
-                                </div>
-                                <div className="p-3">
-                                    <div className="font-medium leading-tight">{g.name}</div>
-                                    {(g.m || g.y) && (
-                                        <div className="text-xs text-[var(--subt)]">{formatEventDate(g.m, g.y)}</div>
-                                    )}
-                                </div>
-                            </Card>
-                        </Link>
+                        <div key={g.id}>
+                            <Link href={g.href} className="no-underline">
+                                <Card className="p-0 overflow-hidden">
+                                    <div className="relative aspect-[4/3] bg-[var(--muted)]">
+                                        {g.thumb ? (
+                                            // eslint-disable-next-line @next/next/no-img-element
+                                            <img src={g.thumb} alt={g.name} className="w-full h-full object-cover" loading="lazy" />
+                                        ) : (
+                                            <div className="w-full h-full" style={{ background: "repeating-linear-gradient(45deg, var(--muted) 0 8px, rgba(0,0,0,.05) 8px 16px)" }} />
+                                        )}
+                                    </div>
+                                    <div className="p-3">
+                                        <div className="font-medium leading-tight">{g.name}</div>
+                                        {(g.m || g.y) && (
+                                            <div className="text-xs text-[var(--subt)]">{formatEventDate(g.m, g.y)}</div>
+                                        )}
+                                    </div>
+                                </Card>
+                            </Link>
+                            <Link href={`/family/galleries/${g.id}/add`} className="block mt-1 text-xs underline">
+                                Add photos
+                            </Link>
+                        </div>
                     ))}
                 </div>
             )}


### PR DESCRIPTION
## Summary
- Allow approved family members to create galleries and upload photos
- Add family-only gallery management pages
- Secure APIs for family gallery creation and image uploads
- Isolate gallery forms into dedicated client components to satisfy Next.js `use client` requirements

## Testing
- `npm test`
- `npm run lint` *(fails: Unexpected any in existing files)*

------
https://chatgpt.com/codex/tasks/task_e_68c7ed0d9fbc83319eb724f89473399a