### PR TITLE
fix: remove async params from gallery add page

### DIFF
--- a/src/app/family/galleries/[id]/add/page.tsx
+++ b/src/app/family/galleries/[id]/add/page.tsx
@@ -10,13 +10,10 @@ import { useState } from "react";
 import { Types } from "mongoose";
 
 export const dynamic = "force-dynamic";
-
-type Params = Promise<{ id: string }>;
-
 type LeanGallery = { _id: Types.ObjectId; name: string; images: string[] };
 
-export default async function AddPhotosPage({ params }: { params: Params }) {
-    const { id } = await params;
+export default async function AddPhotosPage({ params }: { params: { id: string } }) {
+    const { id } = params;
     const supabase = await createClient();
     const { data: { user } } = await supabase.auth.getUser();
     if (!user?.email) return <FamilyLogin />;


### PR DESCRIPTION
## Summary
- accept sync params object in gallery add page

## Testing
- `npm test`
- `npm run lint` *(fails: Unexpected any, no-html-link-for-pages, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68c7f331fd308331af0e775d28b503f1