### PR TITLE
feat: centralize family user auth

### DIFF
--- a/src/app/api/family/galleries/route.ts
+++ b/src/app/api/family/galleries/route.ts
@@ -1,26 +1,22 @@
 // app/api/family/galleries/route.ts
 import { NextRequest, NextResponse } from "next/server";
-import { createClient } from "@/utils/supabase/server";
-import connect from "@/lib/mongodb";
-import FamilyUser from "@/models/FamilyUser";
 import Gallery from "@/models/Gallery";
 import Tag from "@/models/Tag";
 import { ensureGalleryDir, writeBufferFile, uniqueName } from "@/lib/fs-server";
 import { slugify } from "@/lib/slug";
 import { join, extname, basename } from "node:path";
 import { Types } from "mongoose";
+import { getApprovedFamilyUser } from "@/lib/familyAuth";
 
 export const runtime = "nodejs";
 
 export async function POST(req: NextRequest) {
     try {
-        const supabase = await createClient();
-        const { data: { user } } = await supabase.auth.getUser();
-        if (!user?.email) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
-
-        await connect();
-        const dbUser = await FamilyUser.findOne({ email: user.email }).lean();
-        if (dbUser?.status !== "approved") {
+        const { error } = await getApprovedFamilyUser();
+        if (error === "unauthorized") {
+            return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+        }
+        if (error) {
             return NextResponse.json({ error: "Forbidden" }, { status: 403 });
         }
 

--- a/src/app/family/galleries/new/page.tsx
+++ b/src/app/family/galleries/new/page.tsx
@@ -1,19 +1,21 @@
-import { createClient } from "@/utils/supabase/server";
-import connect from "@/lib/mongodb";
-import FamilyUser from "@/models/FamilyUser";
 import FamilyLogin from "@/components/FamilyLogin";
 import Form from "./Form";
+import { getApprovedFamilyUser } from "@/lib/familyAuth";
 
 export const dynamic = "force-dynamic";
 
 export default async function NewFamilyGallery() {
-    const supabase = await createClient();
-    const { data: { user } } = await supabase.auth.getUser();
-    if (!user?.email) return <FamilyLogin />;
-
-    await connect();
-    const dbUser = await FamilyUser.findOne({ email: user.email }).lean();
-    if (dbUser?.status !== "approved") {
+    const { error } = await getApprovedFamilyUser();
+    if (error === "unauthorized") return <FamilyLogin />;
+    if (error === "blocked") {
+        return (
+            <div className="space-y-4">
+                <h1 className="retro-title">Family</h1>
+                <div className="text-sm text-[var(--subt)]">Your access has been blocked.</div>
+            </div>
+        );
+    }
+    if (error) {
         return (
             <div className="space-y-4">
                 <h1 className="retro-title">Family</h1>

--- a/src/lib/familyAuth.ts
+++ b/src/lib/familyAuth.ts
@@ -1,0 +1,49 @@
+import { createClient } from "@/utils/supabase/server";
+import connect from "@/lib/mongodb";
+import FamilyUser from "@/models/FamilyUser";
+import { Types } from "mongoose";
+
+export type FamilyAuthError = "unauthorized" | "pending" | "blocked";
+
+export interface FamilyUserDoc {
+    _id: Types.ObjectId;
+    email: string;
+    name?: string;
+    status: "pending" | "approved" | "blocked";
+}
+
+export async function getApprovedFamilyUser(opts: { upsert?: boolean } = {}) {
+    const supabase = await createClient();
+    const { data: { user } } = await supabase.auth.getUser();
+    if (!user?.email) {
+        return { error: "unauthorized" as FamilyAuthError };
+    }
+
+    await connect();
+    let dbUser: FamilyUserDoc | null;
+    if (opts.upsert) {
+        dbUser = await FamilyUser.findOneAndUpdate(
+            { email: user.email },
+            {
+                $setOnInsert: {
+                    name: (user.user_metadata as { full_name?: string } | null)?.full_name || user.email,
+                    status: "pending",
+                },
+            },
+            { upsert: true, new: true, setDefaultsOnInsert: true }
+        ).lean<FamilyUserDoc>();
+    } else {
+        dbUser = await FamilyUser.findOne({ email: user.email }).lean<FamilyUserDoc | null>();
+    }
+
+    if (!dbUser) {
+        return { error: "unauthorized" as FamilyAuthError };
+    }
+    if (dbUser.status === "blocked") {
+        return { error: "blocked" as FamilyAuthError };
+    }
+    if (dbUser.status !== "approved") {
+        return { error: "pending" as FamilyAuthError };
+    }
+    return { user: dbUser };
+}


### PR DESCRIPTION
## Summary
- add `getApprovedFamilyUser` helper to standardize family auth logic
- refactor family pages and API routes to use the helper

## Testing
- `npm test`
- `npm run lint` *(fails: Unexpected any, other pre-existing lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_68c7f5f55a2083319724db70381842ad