### PR TITLE
Fix family gallery upload flow and require event date

### DIFF
--- a/src/app/api/family/galleries/[id]/upload/route.ts
+++ b/src/app/api/family/galleries/[id]/upload/route.ts
@@ -7,6 +7,7 @@ import { slugify } from "@/lib/slug";
 import { join, extname, basename } from "node:path";
 import { Types } from "mongoose";
 import { getApprovedFamilyUser } from "@/lib/familyAuth";
+import connect from "@/lib/mongodb";
 
 export const runtime = "nodejs";
 
@@ -19,6 +20,8 @@ export async function POST(req: NextRequest, ctx: { params: Promise<{ id: string
     if (error) {
         return NextResponse.json({ error: "Forbidden" }, { status: 403 });
     }
+
+    await connect();
 
     const familyTag = await Tag.findOne({ name: /^family$/i }).select("_id").lean<{ _id: Types.ObjectId } | null>();
     const g = await Gallery.findOne({ _id: id, tags: familyTag?._id });

--- a/src/app/api/family/galleries/route.ts
+++ b/src/app/api/family/galleries/route.ts
@@ -7,6 +7,7 @@ import { slugify } from "@/lib/slug";
 import { join, extname, basename } from "node:path";
 import { Types } from "mongoose";
 import { getApprovedFamilyUser } from "@/lib/familyAuth";
+import connect from "@/lib/mongodb";
 
 export const runtime = "nodejs";
 
@@ -36,6 +37,16 @@ export async function POST(req: NextRequest) {
 
         const eventMonthRaw = form.get("eventMonth");
         const eventYearRaw = form.get("eventYear");
+        const monthNum = Number(eventMonthRaw);
+        const yearNum = Number(eventYearRaw);
+        if (!eventMonthRaw || Number.isNaN(monthNum) || monthNum < 1 || monthNum > 12) {
+            return NextResponse.json({ error: "Event month is required" }, { status: 400 });
+        }
+        if (!eventYearRaw || Number.isNaN(yearNum) || yearNum < 1900 || yearNum > 3000) {
+            return NextResponse.json({ error: "Event year is required" }, { status: 400 });
+        }
+
+        await connect();
 
         // Find or create the family tag
         const familyTag = await Tag.findOneAndUpdate(
@@ -64,8 +75,8 @@ export async function POST(req: NextRequest) {
             slug,
             images: urls,
             tags: [familyTag._id],
-            eventMonth: eventMonthRaw ? Number(eventMonthRaw) : undefined,
-            eventYear: eventYearRaw ? Number(eventYearRaw) : undefined,
+            eventMonth: monthNum,
+            eventYear: yearNum,
             createdAt: new Date(),
             updatedAt: new Date(),
         });

--- a/src/app/family/galleries/[id]/add/Client.tsx
+++ b/src/app/family/galleries/[id]/add/Client.tsx
@@ -1,0 +1,33 @@
+"use client";
+
+import { useState } from "react";
+import { Card } from "@/components/ui/Card";
+import Uploader from "@/components/Uploader";
+
+type ClientProps = { id: string; name: string; initialImages: string[] };
+
+export default function Client({ id, name, initialImages }: ClientProps) {
+    const [images, setImages] = useState(initialImages);
+
+    return (
+        <div className="space-y-3">
+            <h1 className="retro-title">Add Photos – {name}</h1>
+            <Card className="space-y-2 p-4">
+                <Uploader
+                    multiple
+                    accept="image/*"
+                    to={`/api/family/galleries/${id}/upload`}
+                    onUploaded={(urls) => setImages((prev) => [...prev, ...urls])}
+                />
+                {images.length > 0 && (
+                    <div className="flex flex-wrap gap-2">
+                        {images.map((src, i) => (
+                            // eslint-disable-next-line @next/next/no-img-element
+                            <img key={i} src={src} alt="img" className="w-24 h-24 object-cover" />
+                        ))}
+                    </div>
+                )}
+            </Card>
+        </div>
+    );
+}

--- a/src/app/family/galleries/[id]/add/page.tsx
+++ b/src/app/family/galleries/[id]/add/page.tsx
@@ -1,11 +1,10 @@
 import Gallery from "@/models/Gallery";
 import Tag from "@/models/Tag";
 import FamilyLogin from "@/components/FamilyLogin";
-import { Card } from "@/components/ui/Card";
-import Uploader from "@/components/Uploader";
-import { useState } from "react";
 import { Types } from "mongoose";
 import { getApprovedFamilyUser } from "@/lib/familyAuth";
+import connect from "@/lib/mongodb";
+import Client from "./Client";
 
 export const dynamic = "force-dynamic";
 type LeanGallery = { _id: Types.ObjectId; name: string; images: string[] };
@@ -31,6 +30,8 @@ export default async function AddPhotosPage({ params }: { params: { id: string }
         );
     }
 
+    await connect();
+
     const familyTag = await Tag.findOne({ name: /^family$/i }).select("_id").lean<{ _id: Types.ObjectId } | null>();
     const g = await Gallery.findOne({ _id: id, tags: familyTag?._id }).lean<LeanGallery | null>();
     if (!g) {
@@ -43,30 +44,4 @@ export default async function AddPhotosPage({ params }: { params: { id: string }
     }
 
     return <Client id={id} name={g.name} initialImages={g.images} />;
-}
-
-function Client({ id, name, initialImages }: { id: string; name: string; initialImages: string[] }) {
-    "use client";
-    const [images, setImages] = useState(initialImages);
-    return (
-        <div className="space-y-3">
-            <h1 className="retro-title">Add Photos – {name}</h1>
-            <Card className="space-y-2 p-4">
-                <Uploader
-                    multiple
-                    accept="image/*"
-                    to={`/api/family/galleries/${id}/upload`}
-                    onUploaded={(urls) => setImages((prev) => [...prev, ...urls])}
-                />
-                {images.length > 0 && (
-                    <div className="flex flex-wrap gap-2">
-                        {images.map((src, i) => (
-                            // eslint-disable-next-line @next/next/no-img-element
-                            <img key={i} src={src} alt="img" className="w-24 h-24 object-cover" />
-                        ))}
-                    </div>
-                )}
-            </Card>
-        </div>
-    );
 }

--- a/src/app/family/galleries/new/Form.tsx
+++ b/src/app/family/galleries/new/Form.tsx
@@ -5,10 +5,27 @@ import { Card } from '@/components/ui/Card';
 import { Button } from '@/components/ui/Button';
 import { Input } from '@/components/ui/Input';
 
+const MONTHS = [
+    { value: '1', label: 'January' },
+    { value: '2', label: 'February' },
+    { value: '3', label: 'March' },
+    { value: '4', label: 'April' },
+    { value: '5', label: 'May' },
+    { value: '6', label: 'June' },
+    { value: '7', label: 'July' },
+    { value: '8', label: 'August' },
+    { value: '9', label: 'September' },
+    { value: '10', label: 'October' },
+    { value: '11', label: 'November' },
+    { value: '12', label: 'December' },
+];
+
 export default function Form() {
     const [name, setName] = useState('');
     const [files, setFiles] = useState<FileList | null>(null);
     const [previews, setPreviews] = useState<string[]>([]);
+    const [eventMonth, setEventMonth] = useState('');
+    const [eventYear, setEventYear] = useState('');
     const [busy, setBusy] = useState(false);
 
     const onPickFiles: React.ChangeEventHandler<HTMLInputElement> = (e) => {
@@ -30,17 +47,25 @@ export default function Form() {
 
     const submit: React.FormEventHandler = async (e) => {
         e.preventDefault();
+        if (!eventMonth || !eventYear) {
+            alert('Select the event month and year');
+            return;
+        }
         setBusy(true);
         try {
             const form = new FormData();
             form.set('name', name);
             if (files) Array.from(files).forEach((f) => form.append('files', f));
+            form.set('eventMonth', eventMonth);
+            form.set('eventYear', eventYear);
             const res = await fetch('/api/family/galleries', { method: 'POST', body: form });
             const data = await res.json();
             if (!res.ok) throw new Error(data?.error || 'Create failed');
             setName('');
             setFiles(null);
             setPreviews([]);
+            setEventMonth('');
+            setEventYear('');
             alert('Gallery created');
         } catch (err) {
             console.error(err);
@@ -55,7 +80,35 @@ export default function Form() {
             <h1 className="retro-title">New Family Gallery</h1>
             <Card className="space-y-2">
                 <form onSubmit={submit} className="grid gap-2">
-                    <Input placeholder="Name" value={name} onChange={(e) => setName(e.target.value)} />
+                    <Input placeholder="Name" value={name} onChange={(e) => setName(e.target.value)} required />
+                    <div className="grid gap-1">
+                        <label className="retro-label" htmlFor="eventMonth">Event month</label>
+                        <select
+                            id="eventMonth"
+                            className="retro-input"
+                            value={eventMonth}
+                            onChange={(e) => setEventMonth(e.target.value)}
+                            required
+                        >
+                            <option value="" disabled hidden>
+                                Select month
+                            </option>
+                            {MONTHS.map((m) => (
+                                <option key={m.value} value={m.value}>
+                                    {m.label}
+                                </option>
+                            ))}
+                        </select>
+                    </div>
+                    <Input
+                        placeholder="Event year"
+                        type="number"
+                        min={1900}
+                        max={3000}
+                        value={eventYear}
+                        onChange={(e) => setEventYear(e.target.value)}
+                        required
+                    />
                     <input type="file" multiple accept="image/*" onChange={onPickFiles} />
                     {previews.length > 0 && (
                         <div className="flex flex-wrap gap-2">


### PR DESCRIPTION
## Summary
- move the family add-photos UI into a dedicated client component and establish a DB connection before querying
- require event month and year when family members create a gallery, validating in both the form and API
- ensure the family gallery upload API connects to MongoDB before working with galleries

## Testing
- npm run lint *(fails: existing lint errors in unrelated admin and API files)*
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68c85a566c70833195b9202334da0bd8