### PR TITLE
Add entry wall landing and admin management

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "build": "next build",
     "start": "next start",
     "lint": "next lint",
-    "test": "tsx --test test/basic.test.ts test/posts.api.test.ts"
+    "test": "tsx --test test/basic.test.ts test/posts.api.test.ts test/entries.api.test.ts"
   },
   "dependencies": {
     "@supabase/ssr": "^0.7.0",

--- a/src/app/admin/entries/new/page.tsx
+++ b/src/app/admin/entries/new/page.tsx
@@ -1,0 +1,124 @@
+"use client";
+
+import { useMemo, useState } from "react";
+import { Card } from "@/components/ui/Card";
+import { Input } from "@/components/ui/Input";
+import { Button } from "@/components/ui/Button";
+import Uploader from "@/components/Uploader";
+
+type EntryForm = {
+    title: string;
+    caption: string;
+    imageUrl: string;
+    date: string;
+};
+
+export default function NewEntryPage() {
+    const today = useMemo(() => new Date().toISOString().slice(0, 10), []);
+    const [entry, setEntry] = useState<EntryForm>({
+        title: "",
+        caption: "",
+        imageUrl: "",
+        date: today,
+    });
+    const [saving, setSaving] = useState(false);
+    const [msg, setMsg] = useState<string | null>(null);
+
+    const onSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
+        e.preventDefault();
+        setSaving(true);
+        setMsg(null);
+        try {
+            const payload: Record<string, unknown> = {
+                title: entry.title,
+                caption: entry.caption,
+                imageUrl: entry.imageUrl,
+            };
+            if (entry.date) {
+                payload.publishedAt = new Date(`${entry.date}T00:00:00`).toISOString();
+            }
+
+            const res = await fetch("/api/entries", {
+                method: "POST",
+                headers: { "Content-Type": "application/json" },
+                body: JSON.stringify(payload),
+            });
+            if (!res.ok) {
+                const raw = (await res.json().catch(() => ({}))) as unknown;
+                const message =
+                    typeof raw === "object" && raw !== null && "message" in raw && typeof (raw as { message?: unknown }).message === "string"
+                        ? (raw as { message: string }).message
+                        : undefined;
+                throw new Error(message || "Failed to create entry");
+            }
+
+            setMsg("Saved!");
+            setEntry({ title: "", caption: "", imageUrl: "", date: today });
+        } catch (error: unknown) {
+            setMsg(error instanceof Error ? error.message : "Error");
+        } finally {
+            setSaving(false);
+        }
+    };
+
+    return (
+        <div className="p-4 max-w-2xl mx-auto">
+            <h1 className="retro-title mb-3">Create Entry</h1>
+            <Card className="p-4">
+                <form onSubmit={onSubmit} className="grid gap-3">
+                    {msg && <div className="text-sm">{msg}</div>}
+
+                    <Input
+                        placeholder="Title"
+                        value={entry.title}
+                        onChange={(e) => setEntry((v) => ({ ...v, title: e.target.value }))}
+                    />
+
+                    <Input
+                        type="date"
+                        value={entry.date}
+                        onChange={(e) => setEntry((v) => ({ ...v, date: e.target.value }))}
+                    />
+
+                    <Uploader
+                        multiple={false}
+                        accept="image/*"
+                        onUploaded={(urls) =>
+                            setEntry((v) => ({ ...v, imageUrl: urls[0] ?? v.imageUrl }))
+                        }
+                    />
+
+                    {entry.imageUrl && (
+                        // eslint-disable-next-line @next/next/no-img-element
+                        <img src={entry.imageUrl} alt="preview" className="w-full rounded border border-[var(--border)]" />
+                    )}
+
+                    <Input
+                        placeholder="Image URL"
+                        value={entry.imageUrl}
+                        onChange={(e) => setEntry((v) => ({ ...v, imageUrl: e.target.value }))}
+                    />
+
+                    <textarea
+                        className="retro-input min-h-[120px]"
+                        placeholder="Caption"
+                        value={entry.caption}
+                        onChange={(e) => setEntry((v) => ({ ...v, caption: e.target.value }))}
+                    />
+
+                    <div className="flex gap-2">
+                        <Button type="submit" variant="primary" disabled={saving}>
+                            {saving ? "Saving…" : "Save Entry"}
+                        </Button>
+                        <Button
+                            type="button"
+                            onClick={() => setEntry({ title: "", caption: "", imageUrl: "", date: today })}
+                        >
+                            Clear
+                        </Button>
+                    </div>
+                </form>
+            </Card>
+        </div>
+    );
+}

--- a/src/app/admin/entries/page.tsx
+++ b/src/app/admin/entries/page.tsx
@@ -1,0 +1,199 @@
+"use client";
+
+import { useState } from "react";
+import { Button } from "@/components/ui/Button";
+import { Input } from "@/components/ui/Input";
+import { Card } from "@/components/ui/Card";
+import Uploader from "@/components/Uploader";
+
+type EntryRec = {
+    _id: string;
+    title: string;
+    caption: string;
+    imageUrl: string;
+    publishedAt?: string;
+};
+
+export default function ManageEntriesPage() {
+    const [q, setQ] = useState("");
+    const [hasSearched, setHasSearched] = useState(false);
+    const [loading, setLoading] = useState(false);
+    const [rows, setRows] = useState<EntryRec[]>([]);
+    const [edits, setEdits] = useState<Record<string, EntryRec>>({});
+
+    const search = async () => {
+        setHasSearched(true);
+        setLoading(true);
+        const res = await fetch(`/api/entries${q ? `?q=${encodeURIComponent(q)}` : ""}`);
+        const data: unknown = await res.json();
+
+        const toIso = (value: unknown) => {
+            if (!value) return "";
+            const date = typeof value === "string" || value instanceof Date ? new Date(value) : null;
+            return date && !Number.isNaN(date.valueOf()) ? date.toISOString() : "";
+        };
+
+        const normalized: EntryRec[] = Array.isArray(data)
+            ? data
+                  .map((entry) => {
+                      if (!entry || typeof entry !== "object") {
+                          return {
+                              _id: "",
+                              title: "",
+                              caption: "",
+                              imageUrl: "",
+                              publishedAt: "",
+                          };
+                      }
+
+                      const obj = entry as Record<string, unknown>;
+                      const idValue = obj._id;
+                      const id =
+                          typeof idValue === "string"
+                              ? idValue
+                              : idValue && typeof idValue === "object" && "toString" in idValue
+                                  ? String((idValue as { toString(): unknown }).toString())
+                                  : "";
+
+                      const title = typeof obj.title === "string" ? obj.title : "";
+                      const caption = typeof obj.caption === "string" ? obj.caption : "";
+                      const imageUrl = typeof obj.imageUrl === "string" ? obj.imageUrl : "";
+                      const publishedAt = toIso(obj.publishedAt) || toIso(obj.createdAt);
+
+                      return { _id: id, title, caption, imageUrl, publishedAt };
+                  })
+                  .filter((entry) => entry._id.length > 0)
+            : [];
+        setRows(normalized);
+        setEdits(Object.fromEntries(normalized.map((entry) => [entry._id, { ...entry }])));
+        setLoading(false);
+    };
+
+    const save = async (id: string) => {
+        const entry = edits[id];
+        const payload: Record<string, unknown> = {
+            title: entry.title,
+            caption: entry.caption,
+            imageUrl: entry.imageUrl,
+        };
+        if (entry.publishedAt) payload.publishedAt = entry.publishedAt;
+
+        await fetch(`/api/entries/${id}`, {
+            method: "PUT",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify(payload),
+        });
+        await search();
+    };
+
+    const del = async (id: string) => {
+        await fetch(`/api/entries/${id}`, { method: "DELETE" });
+        await search();
+    };
+
+    return (
+        <div className="space-y-3">
+            <h1 className="retro-title">Manage Entries</h1>
+
+            <div className="flex items-center gap-2">
+                <Input
+                    placeholder="Search entries (title, caption, id)…"
+                    value={q}
+                    onChange={(e) => setQ(e.target.value)}
+                    onKeyDown={(e) => e.key === "Enter" && search()}
+                />
+                <Button variant="primary" onClick={search}>Search</Button>
+                <Button onClick={() => { setQ(""); search(); }}>Search All</Button>
+                {hasSearched && (
+                    <Button
+                        onClick={() => {
+                            setQ("");
+                            setRows([]);
+                            setEdits({});
+                            setHasSearched(false);
+                        }}
+                    >
+                        Clear
+                    </Button>
+                )}
+            </div>
+
+            {!hasSearched ? null : loading ? (
+                <div className="text-sm text-[var(--subt)]">Searching…</div>
+            ) : rows.length === 0 ? (
+                <div className="text-sm text-[var(--subt)]">No matches.</div>
+            ) : (
+                <div className="grid gap-3">
+                    {rows.map((row) => {
+                        const entry = edits[row._id] ?? row;
+                        const dateValue = entry.publishedAt ? entry.publishedAt.slice(0, 10) : "";
+                        return (
+                            <Card key={row._id} className="space-y-2">
+                                <Input
+                                    value={entry.title}
+                                    onChange={(ev) =>
+                                        setEdits((m) => ({ ...m, [row._id]: { ...entry, title: ev.target.value } }))
+                                    }
+                                    placeholder="Title"
+                                />
+
+                                <Input
+                                    type="date"
+                                    value={dateValue}
+                                    onChange={(ev) => {
+                                        const v = ev.target.value;
+                                        setEdits((m) => ({
+                                            ...m,
+                                            [row._id]: {
+                                                ...entry,
+                                                publishedAt: v ? new Date(`${v}T00:00:00`).toISOString() : "",
+                                            },
+                                        }));
+                                    }}
+                                />
+
+                                <Uploader
+                                    multiple={false}
+                                    accept="image/*"
+                                    onUploaded={(urls) =>
+                                        setEdits((m) => ({
+                                            ...m,
+                                            [row._id]: { ...entry, imageUrl: urls[0] ?? entry.imageUrl },
+                                        }))
+                                    }
+                                />
+
+                                {entry.imageUrl && (
+                                    // eslint-disable-next-line @next/next/no-img-element
+                                    <img src={entry.imageUrl} alt="preview" className="w-full max-w-sm rounded border border-[var(--border)]" />
+                                )}
+
+                                <Input
+                                    value={entry.imageUrl}
+                                    onChange={(ev) =>
+                                        setEdits((m) => ({ ...m, [row._id]: { ...entry, imageUrl: ev.target.value } }))
+                                    }
+                                    placeholder="Image URL"
+                                />
+
+                                <textarea
+                                    className="retro-input min-h-[100px]"
+                                    value={entry.caption}
+                                    onChange={(ev) =>
+                                        setEdits((m) => ({ ...m, [row._id]: { ...entry, caption: ev.target.value } }))
+                                    }
+                                    placeholder="Caption"
+                                />
+
+                                <div className="flex gap-2">
+                                    <Button variant="primary" onClick={() => save(row._id)}>Save</Button>
+                                    <Button onClick={() => del(row._id)}>Delete</Button>
+                                </div>
+                            </Card>
+                        );
+                    })}
+                </div>
+            )}
+        </div>
+    );
+}

--- a/src/app/api/entries/[id]/route.ts
+++ b/src/app/api/entries/[id]/route.ts
@@ -1,0 +1,38 @@
+import { NextResponse } from 'next/server';
+import connect from '@/lib/mongodb';
+import Entry from '@/models/Entry';
+
+type Ctx = { params: Promise<{ id: string }> };
+
+export async function PUT(req: Request, { params }: Ctx) {
+    await connect();
+    const { id } = await params;
+    const raw: unknown = await req.json();
+
+    if (!raw || typeof raw !== 'object') {
+        return NextResponse.json({ message: 'Invalid payload' }, { status: 400 });
+    }
+
+    const data = raw as Record<string, unknown>;
+    const update: Record<string, unknown> = {};
+    if (typeof data.title === 'string') update.title = data.title;
+    if (typeof data.caption === 'string') update.caption = data.caption;
+    if (typeof data.imageUrl === 'string') update.imageUrl = data.imageUrl;
+    if ('publishedAt' in data) {
+        const value = data.publishedAt;
+        const date = typeof value === 'string' || value instanceof Date ? new Date(value) : null;
+        if (date && !Number.isNaN(date.valueOf())) {
+            update.publishedAt = date;
+        }
+    }
+
+    const entry = await Entry.findByIdAndUpdate(id, { $set: update }, { new: true });
+    return NextResponse.json(entry);
+}
+
+export async function DELETE(_req: Request, { params }: Ctx) {
+    await connect();
+    const { id } = await params;
+    await Entry.findByIdAndDelete(id);
+    return NextResponse.json({ ok: true });
+}

--- a/src/app/api/entries/route.ts
+++ b/src/app/api/entries/route.ts
@@ -1,0 +1,59 @@
+import { NextResponse } from 'next/server';
+import connect from '@/lib/mongodb';
+import Entry from '@/models/Entry';
+
+export async function GET(req: Request) {
+    await connect();
+    const { searchParams } = new URL(req.url);
+    const q = searchParams.get('q')?.trim();
+    const limit = Number(searchParams.get('limit') ?? 100);
+
+    const orConditions = q
+        ? [
+              { title: { $regex: q, $options: 'i' } },
+              { caption: { $regex: q, $options: 'i' } },
+              q.match(/^[a-f0-9]{24}$/i) ? { _id: q } : null,
+          ].filter(Boolean)
+        : [];
+
+    const criteria =
+        orConditions.length > 0
+            ? ({ $or: orConditions as Record<string, unknown>[] } as Record<string, unknown>)
+            : ({} as Record<string, unknown>);
+
+    const entries = await Entry.find(criteria, {
+        title: 1,
+        caption: 1,
+        imageUrl: 1,
+        publishedAt: 1,
+        createdAt: 1,
+    })
+        .sort({ publishedAt: -1, createdAt: -1 })
+        .limit(limit);
+
+    return NextResponse.json(entries);
+}
+
+export async function POST(req: Request) {
+    await connect();
+    const raw: unknown = await req.json();
+
+    if (!raw || typeof raw !== 'object') {
+        return NextResponse.json({ message: 'Invalid payload' }, { status: 400 });
+    }
+
+    const data = raw as Record<string, unknown>;
+    const publishedAt = data.publishedAt ? new Date(data.publishedAt as string) : new Date();
+    if (Number.isNaN(publishedAt.valueOf())) {
+        return NextResponse.json({ message: 'Invalid publishedAt' }, { status: 400 });
+    }
+
+    const entry = await Entry.create({
+        title: typeof data.title === 'string' ? data.title : '',
+        caption: typeof data.caption === 'string' ? data.caption : '',
+        imageUrl: typeof data.imageUrl === 'string' ? data.imageUrl : '',
+        publishedAt,
+    });
+
+    return NextResponse.json(entry, { status: 201 });
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,197 +1,87 @@
 // src/app/page.tsx
-import Link from "next/link";
 import connect from "@/lib/mongodb";
-import Post from "@/models/Post";
-import Gallery from "@/models/Gallery";
-import "@/models/Tag";
-import Tag from "@/models/Tag";
-import Carousel from "@/components/Carousel";
+import Entry from "@/models/Entry";
 import { Card } from "@/components/ui/Card";
 import { Types } from "mongoose";
 
-type LeanTag = { _id: Types.ObjectId; name: string; color?: string };
-type LeanGallery = { _id: Types.ObjectId; name: string; images: string[] };
-
-type LeanPost = {
+type LeanEntry = {
     _id: Types.ObjectId;
     title: string;
-    content: string;
-    gallery?: Types.ObjectId | LeanGallery | null;
-    tags?: (Types.ObjectId | LeanTag)[];
+    caption: string;
+    imageUrl: string;
+    publishedAt?: Date;
+    createdAt?: Date;
 };
 
-type LGallery = {
-    _id: Types.ObjectId;
-    name: string;
-    images: string[];
-    tags?: (Types.ObjectId | LeanTag)[];
-};
+const DATE_FORMATTER = new Intl.DateTimeFormat("en-US", { dateStyle: "medium" });
 
-function pickTextColor(hex?: string) {
-    // very small helper to ensure contrast on the badge background
-    if (!hex || !/^#?[0-9a-f]{6}$/i.test(hex)) return "var(--text)";
-    const h = hex.replace("#", "");
-    const r = parseInt(h.slice(0, 2), 16) / 255;
-    const g = parseInt(h.slice(2, 4), 16) / 255;
-    const b = parseInt(h.slice(4, 6), 16) / 255;
-    // perceived luminance
-    const L = 0.2126 * r + 0.7152 * g + 0.0722 * b;
-    return L > 0.55 ? "#000" : "#fff";
+function formatDate(date?: Date | string | null) {
+    if (!date) return "";
+    const value = typeof date === "string" ? new Date(date) : date;
+    if (!(value instanceof Date) || Number.isNaN(value.valueOf())) return "";
+    return DATE_FORMATTER.format(value);
 }
 
 export default async function Home() {
     await connect();
 
-    // -------- Posts (newest first) --------
-    const rawPosts = await Post.find(
-        {},
-        { title: 1, content: 1, gallery: 1, tags: 1, createdAt: 1 }
-    )
-        .sort({ createdAt: -1 })
-        .limit(12)
-        .populate("gallery", "images")
-        .populate("tags", "name color")
-        .lean<LeanPost[]>();
+    const rawEntries = await Entry.find({}, { title: 1, caption: 1, imageUrl: 1, publishedAt: 1, createdAt: 1 })
+        .sort({ publishedAt: -1, createdAt: -1 })
+        .limit(30)
+        .lean<LeanEntry[]>();
 
-    const posts = rawPosts.map((p) => {
-        const id = p._id.toString();
-        const g = p.gallery && typeof p.gallery === "object" ? (p.gallery as LeanGallery) : null;
-        const thumb = g?.images?.[0] ?? "";
-
-        const tags =
-            Array.isArray(p.tags)
-                ? p.tags
-                    .map((t) =>
-                        typeof t === "object"
-                            ? { id: t._id.toString(), name: t.name, color: t.color }
-                            : null
-                    )
-                    .filter(Boolean) as { id: string; name: string; color?: string }[]
-                : [];
-
-        return { id, title: p.title ?? "(untitled)", href: `/blog/${id}`, thumb, tags };
-    });
-
-    // Get the 'family' tag id (if it exists)
-    const familyTag = await Tag.findOne({ name: /^family$/i }).select("_id").lean<{ _id: Types.ObjectId } | null>();
-    const familyId = familyTag?._id;
-
-    // -------- Galleries (newest first) --------
-    const rawGalleries = await Gallery.find(
-        familyId ? { tags: { $nin: [familyId] } } : {}, // exclude family if tag exists
-        { name: 1, images: 1, tags: 1, createdAt: 1 }
-    )
-        .sort({ createdAt: -1 })
-        .limit(12)
-        .populate("tags", "name color")
-        .lean<LGallery[]>();
-
-    const galleries = rawGalleries.map((g) => {
-        const id = g._id.toString();
-        const thumb = Array.isArray(g.images) && g.images.length > 0 ? g.images[0] : "";
-
-        const tags =
-            Array.isArray(g.tags)
-                ? g.tags
-                    .map((t) =>
-                        typeof t === "object"
-                            ? { id: t._id.toString(), name: t.name, color: t.color }
-                            : null
-                    )
-                    .filter(Boolean) as { id: string; name: string; color?: string }[]
-                : [];
-
-        return { id, name: g.name ?? "(untitled)", href: `/galleries/${id}`, thumb, tags };
-    });
-
-    // -------- Card using your ui/Card + retro badges --------
-    function ThumbCard({
-                           href,
-                           title,
-                           thumb,
-                           tags,
-                       }: {
-        href: string;
-        title: string;
-        thumb?: string;
-        tags?: { id: string; name: string; color?: string }[];
-    }) {
-        const shown = (tags ?? []).slice(0, 3);
-        const extra = (tags?.length ?? 0) - shown.length;
-
-        return (
-            <Link href={href} className="snap-start no-underline">
-                <Card className="p-0 min-w-[240px] w-[240px] overflow-hidden">
-                    <div className="relative aspect-[4/3] w-full bg-[var(--muted)] overflow-hidden">
-                        {thumb ? (
-                            // eslint-disable-next-line @next/next/no-img-element
-                            <img src={thumb} alt={title} className="w-full h-full object-cover block" loading="lazy" />
-                        ) : (
-                            <div
-                                className="w-full h-full"
-                                style={{
-                                    background:
-                                        "repeating-linear-gradient(45deg, var(--muted) 0 8px, rgba(0,0,0,.05) 8px 16px)",
-                                }}
-                            />
-                        )}
-
-                        {/* retro badges overlay */}
-                        {shown.length > 0 && (
-                            <div className="absolute left-1 bottom-1 flex flex-wrap gap-1">
-                                {shown.map((t) => (
-                                    <span
-                                        key={t.id}
-                                        className="px-2 py-0.5 text-[10px] leading-tight border rounded-[2px]"
-                                        style={{
-                                            backgroundColor: t.color || "var(--surface)",
-                                            color: pickTextColor(t.color),
-                                            borderColor: "var(--border)",
-                                            boxShadow: "2px 2px 0 0 rgba(0,0,0,0.85)", // retro shadow
-                                        }}
-                                        title={t.name}
-                                    >
-                    {t.name}
-                  </span>
-                                ))}
-                                {extra > 0 && (
-                                    <span
-                                        className="px-2 py-0.5 text-[10px] leading-tight border rounded-[2px]"
-                                        style={{
-                                            backgroundColor: "var(--surface)",
-                                            color: "var(--text)",
-                                            borderColor: "var(--border)",
-                                            boxShadow: "2px 2px 0 0 rgba(0,0,0,0.85)",
-                                        }}
-                                        title={`${extra} more`}
-                                    >
-                    +{extra}
-                  </span>
-                                )}
-                            </div>
-                        )}
-                    </div>
-                    <div className="p-3">
-                        <div className="font-medium leading-tight">{title}</div>
-                    </div>
-                </Card>
-            </Link>
-        );
-    }
+    const entries = rawEntries.map((entry) => ({
+        id: entry._id.toString(),
+        title: entry.title ?? "(untitled)",
+        caption: entry.caption ?? "",
+        imageUrl: entry.imageUrl ?? "",
+        publishedAt: entry.publishedAt ?? entry.createdAt ?? null,
+    }));
 
     return (
-        <div className="p-4 space-y-6">
-            <Carousel title="Latest Posts">
-                {posts.map((p) => (
-                    <ThumbCard key={p.id} href={p.href} title={p.title} thumb={p.thumb} tags={p.tags} />
-                ))}
-            </Carousel>
+        <div className="space-y-4">
+            <h1 className="retro-title">Latest Entries</h1>
 
-            <Carousel title="Latest Galleries">
-                {galleries.map((g) => (
-                    <ThumbCard key={g.id} href={g.href} title={g.name} thumb={g.thumb} tags={g.tags} />
-                ))}
-            </Carousel>
+            {entries.length === 0 ? (
+                <div className="text-sm text-[var(--subt)]">No entries yet. Check back soon!</div>
+            ) : (
+                <div className="grid gap-6 sm:grid-cols-2 xl:grid-cols-3">
+                    {entries.map((entry) => (
+                        <Card key={entry.id} className="overflow-hidden flex flex-col">
+                            <div className="relative aspect-[4/3] w-full bg-[var(--muted)]">
+                                {entry.imageUrl ? (
+                                    // eslint-disable-next-line @next/next/no-img-element
+                                    <img
+                                        src={entry.imageUrl}
+                                        alt={entry.title}
+                                        className="w-full h-full object-cover"
+                                        loading="lazy"
+                                    />
+                                ) : (
+                                    <div
+                                        className="w-full h-full"
+                                        style={{
+                                            background:
+                                                "repeating-linear-gradient(45deg, var(--muted) 0 8px, rgba(0,0,0,.05) 8px 16px)",
+                                        }}
+                                    />
+                                )}
+                            </div>
+                            <div className="p-4 space-y-2 flex-1 flex flex-col">
+                                <div>
+                                    <div className="font-semibold text-lg leading-tight">{entry.title}</div>
+                                    {entry.publishedAt && (
+                                        <div className="text-xs text-[var(--subt)] uppercase tracking-wide">
+                                            {formatDate(entry.publishedAt)}
+                                        </div>
+                                    )}
+                                </div>
+                                <p className="text-sm text-[var(--text)] whitespace-pre-line flex-1">{entry.caption}</p>
+                            </div>
+                        </Card>
+                    ))}
+                </div>
+            )}
         </div>
     );
 }

--- a/src/components/admin/AdminShell.tsx
+++ b/src/components/admin/AdminShell.tsx
@@ -5,11 +5,10 @@ import { usePathname } from "next/navigation";
 import { useEffect, useState } from "react";
 import { Button } from "@/components/ui/Button";
 import { Card } from "@/components/ui/Card";
-import GalleryPicker from "@/components/admin/GalleryPicker";
-
-
 const NAV = [
     { href: "/admin", label: "Dashboard" },
+    { href: "/admin/entries/new", label: "Create Entry" },
+    { href: "/admin/entries", label: "Manage Entries" },
     { href: "/admin/posts/new", label: "Create Post" },
     { href: "/admin/posts", label: "Manage Posts" },
     { href: "/admin/galleries/new", label: "Create Gallery" },

--- a/src/models/Entry.ts
+++ b/src/models/Entry.ts
@@ -1,0 +1,20 @@
+import { Schema, model, models } from 'mongoose';
+
+export interface EntryDoc {
+  title: string;
+  caption: string;
+  imageUrl: string;
+  publishedAt: Date;
+}
+
+const EntrySchema = new Schema<EntryDoc>(
+  {
+    title: { type: String, required: true },
+    caption: { type: String, required: true },
+    imageUrl: { type: String, required: true },
+    publishedAt: { type: Date, required: true, default: Date.now },
+  },
+  { timestamps: true }
+);
+
+export default models.Entry || model<EntryDoc>('Entry', EntrySchema);

--- a/test/entries.api.test.ts
+++ b/test/entries.api.test.ts
@@ -1,0 +1,15 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+test('entries GET handler exists', async () => {
+  process.env.MONGODB_URI = 'mongodb://localhost/test';
+  const { GET } = await import('@/app/api/entries/route');
+  assert.strictEqual(typeof GET, 'function');
+});
+
+test('entries POST handler exists', async () => {
+  process.env.MONGODB_URI = 'mongodb://localhost/test';
+  const { POST } = await import('@/app/api/entries/route');
+  assert.strictEqual(typeof POST, 'function');
+});
+


### PR DESCRIPTION
## Summary
- replace the home page carousels with a masonry-style wall fed by entry documents and normalized 4:3 media
- introduce an Entry model with CRUD API routes plus smoke tests for the new endpoints
- add admin pages for creating and managing entries and update the navigation accordingly

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68c8712f9e808331934b291ed8a2295e