### PR TITLE
Make entry list scrollable and add tag management

### DIFF
--- a/src/app/api/entries/route.ts
+++ b/src/app/api/entries/route.ts
@@ -27,6 +27,7 @@ export async function GET(req: Request) {
         imageUrl: 1,
         publishedAt: 1,
         createdAt: 1,
+        tags: 1,
     })
         .sort({ publishedAt: -1, createdAt: -1 })
         .limit(limit);
@@ -53,6 +54,11 @@ export async function POST(req: Request) {
         caption: typeof data.caption === 'string' ? data.caption : '',
         imageUrl: typeof data.imageUrl === 'string' ? data.imageUrl : '',
         publishedAt,
+        tags: Array.isArray(data.tags)
+            ? data.tags
+                  .map((value) => (typeof value === 'string' ? value : null))
+                  .filter((value): value is string => Boolean(value))
+            : [],
     });
 
     return NextResponse.json(entry, { status: 201 });

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -176,11 +176,16 @@ html, body {
 /* ... keep your existing theme + palette ... */
 
 .site-bg {
+    --site-pad-top: 24px;
+    --site-pad-bottom: 40px;
     min-height: 100svh;
+    height: 100svh;
+    box-sizing: border-box;
+    overflow: hidden;
     display: flex;
     justify-content: center;     /* center horizontally */
     align-items: flex-start;     /* stick near the top */
-    padding: 24px 16px 40px;     /* top/side/bottom padding */
+    padding: var(--site-pad-top) 16px var(--site-pad-bottom);     /* top/side/bottom padding */
     background-color: var(--bg);
 
     /* keep your layered retro background */
@@ -193,7 +198,9 @@ html, body {
 }
 
 @media (min-width: 768px) {
-    .site-bg { padding-top: 48px; }   /* a bit more breathing room on desktop */
+    .site-bg {
+        --site-pad-top: 48px;   /* a bit more breathing room on desktop */
+    }
 }
 
 .app-frame {
@@ -203,7 +210,17 @@ html, body {
     border: 1px solid var(--border);
     border-radius: theme(--radius-retro);
     box-shadow: theme(--shadow-retro);
-    overflow: clip;
+    overflow: hidden;
+    display: flex;
+    flex-direction: column;
+    max-height: calc(100svh - var(--site-pad-top) - var(--site-pad-bottom));
+}
+
+.app-content {
+    flex: 1;
+    min-height: 0; /* allow flex child to scroll */
+    overflow-y: auto;
+    -webkit-overflow-scrolling: touch;
 }
 
 /* Bigger, catchy post titles (auto scales) */

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -52,7 +52,7 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
                 </nav>
 
                 {/* Page content */}
-                <main className="p-4 md:p-6">{children}</main>
+                <main className="app-content p-4 md:p-6">{children}</main>
             </div>
         </div>
         </body>

--- a/src/models/Entry.ts
+++ b/src/models/Entry.ts
@@ -1,10 +1,11 @@
-import { Schema, model, models } from 'mongoose';
+import { Schema, model, models, type Types } from 'mongoose';
 
 export interface EntryDoc {
   title: string;
   caption: string;
   imageUrl: string;
   publishedAt: Date;
+  tags: Types.ObjectId[];
 }
 
 const EntrySchema = new Schema<EntryDoc>(
@@ -13,6 +14,7 @@ const EntrySchema = new Schema<EntryDoc>(
     caption: { type: String, required: true },
     imageUrl: { type: String, required: true },
     publishedAt: { type: Date, required: true, default: Date.now },
+    tags: [{ type: Schema.Types.ObjectId, ref: 'Tag', default: [] }],
   },
   { timestamps: true }
 );


### PR DESCRIPTION
## Summary
- keep the top toolbar fixed while the entry list scrolls by turning the app frame into a flex column and applying overflow to the main content area
- let entry authors pick tags on both the create-entry form and the entries management screen, including fetching available tags up front
- persist entry tags through the API/model updates and delete any local upload that belonged to a removed entry

## Testing
- npm test
- npm run lint *(fails: existing lint errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68c8790646a883318c2a6203b5e402af