### PR TITLE
Add slug field to gallery schema

### DIFF
--- a/src/models/Gallery.ts
+++ b/src/models/Gallery.ts
@@ -3,6 +3,7 @@ import { Schema, model, models } from 'mongoose';
 const GallerySchema = new Schema(
   {
     name: { type: String, required: true },
+    slug: { type: String, required: true, trim: true, unique: true },
     images: { type: [String], default: [] },
     passwordHash: { type: String },
     tags: [{ type: Schema.Types.ObjectId, ref: 'Tag', default: [] }],
@@ -13,5 +14,6 @@ const GallerySchema = new Schema(
 );
 
 GallerySchema.index({ eventYear: 1, eventMonth: 1 });
+GallerySchema.index({ slug: 1 }, { unique: true });
 
 export default models.Gallery || model('Gallery', GallerySchema);


### PR DESCRIPTION
## Summary
- add a slug field to the Gallery schema so uploads can persist and reuse the folder slug
- add a unique index on slug to avoid collisions when generating gallery directories

## Testing
- npm run test
- npm run lint *(fails: pre-existing lint errors in admin and API files)*

------
https://chatgpt.com/codex/tasks/task_e_68caf1c492808331a4facc0c34533d5f