### PR TITLE
Mark home page as dynamic

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -4,6 +4,8 @@ import Entry from "@/models/Entry";
 import { Card } from "@/components/ui/Card";
 import { Types } from "mongoose";
 
+export const dynamic = "force-dynamic";
+
 type LeanEntry = {
     _id: Types.ObjectId;
     title: string;


### PR DESCRIPTION
## Summary
- mark the home page in `src/app/page.tsx` as dynamic so it always renders on demand

## Testing
- `npm run lint` *(fails: existing lint violations in admin and API files unrelated to this change)*
- `npm run dev` *(fails at runtime without Supabase environment variables, preventing UI verification)*

------
https://chatgpt.com/codex/tasks/task_e_68cd0eddacb883319c30c0503ab43f0d