### PR TITLE
Store uploads outside Next public directory

### DIFF
--- a/src/app/api/entries/[id]/route.ts
+++ b/src/app/api/entries/[id]/route.ts
@@ -3,6 +3,7 @@ import { unlink } from 'fs/promises';
 import path from 'path';
 import connect from '@/lib/mongodb';
 import Entry from '@/models/Entry';
+import { PUBLIC_DIR, UPLOADS_DIR } from '@/lib/fs-server';
 
 type Ctx = { params: Promise<{ id: string }> };
 
@@ -43,9 +44,9 @@ export async function DELETE(_req: Request, { params }: Ctx) {
     const entry = await Entry.findByIdAndDelete(id);
 
     if (entry?.imageUrl && typeof entry.imageUrl === 'string' && entry.imageUrl.startsWith('/uploads/')) {
-        const uploadsDir = path.join(process.cwd(), 'public', 'uploads');
+        const uploadsDir = UPLOADS_DIR;
         const relativePath = entry.imageUrl.replace(/^\/+/u, '');
-        const filePath = path.resolve(process.cwd(), 'public', relativePath);
+        const filePath = path.resolve(PUBLIC_DIR, relativePath);
         if (filePath.startsWith(uploadsDir)) {
             try {
                 await unlink(filePath);

--- a/src/app/api/upload/route.ts
+++ b/src/app/api/upload/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from "next/server";
 import { writeFile, mkdir } from "fs/promises";
 import path from "path";
+import { UPLOADS_DIR } from "@/lib/fs-server";
 
 export const runtime = "nodejs";
 
@@ -9,7 +10,7 @@ export async function POST(request: Request) {
   const files = formData.getAll("files");
   const urls: string[] = [];
 
-  const uploadDir = path.join(process.cwd(), "public/uploads");
+  const uploadDir = UPLOADS_DIR;
   await mkdir(uploadDir, { recursive: true });
 
   for (const file of files) {

--- a/src/lib/fs-server.ts
+++ b/src/lib/fs-server.ts
@@ -2,8 +2,9 @@ import { existsSync, mkdirSync, renameSync, copyFileSync, createWriteStream } fr
 import { join, dirname } from "node:path";
 import { randomUUID } from "node:crypto";
 
-const PUBLIC_DIR = join(process.cwd(), "public");
+export const PUBLIC_DIR = "/root/projects/blog-uploads";
 export const GALLERIES_DIR = join(PUBLIC_DIR, "galleries");
+export const UPLOADS_DIR = join(PUBLIC_DIR, "uploads");
 
 export function ensureDir(path: string) {
     if (!existsSync(path)) mkdirSync(path, { recursive: true });


### PR DESCRIPTION
## Summary
- point server-side file helpers to `/root/projects/blog-uploads` instead of the Next.js public directory
- reuse the shared upload/gallery directory constants inside the upload, entry deletion, and gallery deletion routes
- normalize gallery cleanup to resolve stored URLs against the new upload root

## Testing
- npm run lint *(fails: existing lint errors about `no-explicit-any` in untouched files)*
- npm test


------
https://chatgpt.com/codex/tasks/task_e_68d3d456ec888331bad3d44175227559