### PR TITLE
Refactor uploads to use type-specific storage paths

### DIFF
--- a/src/app/admin/entries/page.tsx
+++ b/src/app/admin/entries/page.tsx
@@ -201,6 +201,8 @@ export default function ManageEntriesPage() {
                                 <Uploader
                                     multiple={false}
                                     accept="image/*"
+                                    targetType="entries"
+                                    targetId={row._id}
                                     onUploaded={(urls) =>
                                         setEdits((m) => ({
                                             ...m,

--- a/src/app/api/entries/new-id/route.ts
+++ b/src/app/api/entries/new-id/route.ts
@@ -1,0 +1,9 @@
+import { NextResponse } from 'next/server';
+import { Types } from 'mongoose';
+
+export const runtime = 'nodejs';
+
+export function GET() {
+    const id = new Types.ObjectId().toHexString();
+    return NextResponse.json({ id });
+}

--- a/src/app/api/entries/route.ts
+++ b/src/app/api/entries/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from 'next/server';
 import connect from '@/lib/mongodb';
 import Entry from '@/models/Entry';
+import { Types } from 'mongoose';
 
 export async function GET(req: Request) {
     await connect();
@@ -49,7 +50,7 @@ export async function POST(req: Request) {
         return NextResponse.json({ message: 'Invalid publishedAt' }, { status: 400 });
     }
 
-    const entry = await Entry.create({
+    const payload: Record<string, unknown> = {
         title: typeof data.title === 'string' ? data.title : '',
         caption: typeof data.caption === 'string' ? data.caption : '',
         imageUrl: typeof data.imageUrl === 'string' ? data.imageUrl : '',
@@ -59,7 +60,13 @@ export async function POST(req: Request) {
                   .map((value) => (typeof value === 'string' ? value : null))
                   .filter((value): value is string => Boolean(value))
             : [],
-    });
+    };
+
+    if (typeof data._id === 'string' && Types.ObjectId.isValid(data._id)) {
+        payload._id = new Types.ObjectId(data._id);
+    }
+
+    const entry = await Entry.create(payload);
 
     return NextResponse.json(entry, { status: 201 });
 }

--- a/src/app/api/upload/route.ts
+++ b/src/app/api/upload/route.ts
@@ -1,7 +1,6 @@
 import { NextResponse } from "next/server";
-import { writeFile, mkdir } from "fs/promises";
 import path from "path";
-import { UPLOADS_DIR } from "@/lib/fs-server";
+import { ensureBlogDir, ensureEntryDir, writeBufferFile, uniqueName } from "@/lib/fs-server";
 
 export const runtime = "nodejs";
 
@@ -10,17 +9,40 @@ export async function POST(request: Request) {
   const files = formData.getAll("files");
   const urls: string[] = [];
 
-  const uploadDir = UPLOADS_DIR;
-  await mkdir(uploadDir, { recursive: true });
+  const targetType = String(formData.get("targetType") || "").trim();
+  const targetId = String(formData.get("targetId") || "").trim();
+
+  if (!targetType || !targetId) {
+    return NextResponse.json({ error: "targetType and targetId are required" }, { status: 400 });
+  }
+
+  if (!/^[a-zA-Z0-9_-]+$/.test(targetId)) {
+    return NextResponse.json({ error: "Invalid targetId" }, { status: 400 });
+  }
+
+  let destDir: string;
+  switch (targetType) {
+    case "entries":
+      destDir = ensureEntryDir(targetId);
+      break;
+    case "blogs":
+      destDir = ensureBlogDir(targetId);
+      break;
+    default:
+      return NextResponse.json({ error: "Unsupported targetType" }, { status: 400 });
+  }
 
   for (const file of files) {
     if (typeof file === "string") continue;
     const arrayBuffer = await file.arrayBuffer();
     const buffer = Buffer.from(arrayBuffer);
-    const uniqueName = `${Date.now()}-${file.name}`;
-    const filePath = path.join(uploadDir, uniqueName);
-    await writeFile(filePath, buffer);
-    urls.push(`/uploads/${uniqueName}`);
+    const originalName = path.basename(file.name);
+    const ext = path.extname(originalName).replace(/^\./, "") || "bin";
+    const base = path.basename(originalName, path.extname(originalName));
+    const filename = uniqueName(base, ext);
+    const filePath = path.join(destDir, filename);
+    await writeBufferFile(filePath, buffer);
+    urls.push(`/${targetType}/${targetId}/${filename}`);
   }
 
   return NextResponse.json({ urls });

--- a/src/components/Uploader.tsx
+++ b/src/components/Uploader.tsx
@@ -9,6 +9,9 @@ interface UploaderProps {
     to?: string;                 // <— where to POST (default /api/upload)
     accept?: string;             // e.g. "image/jpeg,image/png"
     multiple?: boolean;          // default true
+    disabled?: boolean;
+    targetType?: "entries" | "blogs";
+    targetId?: string;
 }
 
 export default function Uploader({
@@ -17,13 +20,23 @@ export default function Uploader({
                                      to = "/api/upload",
                                      accept = "image/*",
                                      multiple = true,
+                                     disabled = false,
+                                     targetType,
+                                     targetId,
                                  }: UploaderProps) {
     const handleChange = async (e: ChangeEvent<HTMLInputElement>) => {
         const files = Array.from(e.target.files ?? []);
         if (files.length === 0) return;
+        if (targetType && !targetId) {
+            console.error("Uploader: targetId is required when targetType is provided");
+            e.target.value = "";
+            return;
+        }
 
         const formData = new FormData();
         files.forEach((file) => formData.append("files", file)); // key must be "files"
+        if (targetType) formData.append("targetType", targetType);
+        if (targetId) formData.append("targetId", targetId);
 
         try {
             const res = await fetch(to, { method: "POST", body: formData });
@@ -44,6 +57,7 @@ export default function Uploader({
             accept={accept}
             onChange={handleChange}
             className={className}
+            disabled={disabled}
         />
     );
 }


### PR DESCRIPTION
## Summary
- update server-side file helpers to manage gallery, entry, and blog upload roots with explicit permissions
- add target-aware uploader flow and entry admin UI updates that reserve Mongo IDs before uploading
- route generic uploads into the new directory structure, support pre-assigned entry IDs, and clean up entry assets on delete

## Testing
- npm run lint *(fails: pre-existing any/no-unused-vars violations in untouched files)*
- npm test


------
https://chatgpt.com/codex/tasks/task_e_68d40322c0908331b49eb4891f1831d1