### PR TITLE
Update upload path to /var/www location

### DIFF
--- a/src/lib/fs-server.ts
+++ b/src/lib/fs-server.ts
@@ -2,7 +2,7 @@ import { existsSync, mkdirSync, renameSync, copyFileSync, createWriteStream, chm
 import { join, dirname } from "node:path";
 import { randomUUID } from "node:crypto";
 
-export const PUBLIC_DIR = "/root/projects/blog-uploads";
+export const PUBLIC_DIR = "/var/www/blog-uploads";
 export const GALLERIES_DIR = join(PUBLIC_DIR, "galleries");
 export const ENTRIES_DIR = join(PUBLIC_DIR, "entries");
 export const BLOGS_DIR = join(PUBLIC_DIR, "blogs");


### PR DESCRIPTION
## Summary
- point the server-side public upload directory to /var/www/blog-uploads for improved security

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d50021877c83319248ed55d56b9027