### PR TITLE
Refactor gallery storage paths

### DIFF
--- a/src/app/api/family/galleries/[id]/upload/route.ts
+++ b/src/app/api/family/galleries/[id]/upload/route.ts
@@ -2,12 +2,13 @@
 import { NextRequest, NextResponse } from "next/server";
 import Gallery from "@/models/Gallery";
 import Tag from "@/models/Tag";
-import { ensureGalleryDir, writeBufferFile, uniqueName } from "@/lib/fs-server";
+import { ensureGalleryDir, writeBufferFile } from "@/lib/fs-server";
 import { slugify } from "@/lib/slug";
-import { join, extname, basename } from "node:path";
+import { join } from "node:path";
 import { Types } from "mongoose";
 import { getApprovedFamilyUser } from "@/lib/familyAuth";
 import connect from "@/lib/mongodb";
+import { resolveGalleryImageUrl, sanitizeGalleryFileName } from "@/lib/galleryPaths";
 
 export const runtime = "nodejs";
 
@@ -28,7 +29,7 @@ export async function POST(req: NextRequest, ctx: { params: Promise<{ id: string
     if (!g) return NextResponse.json({ error: "Not found" }, { status: 404 });
 
     if (!g.slug || typeof g.slug !== "string" || g.slug.trim() === "") {
-        const fallbackName = typeof g.name === "string" && g.name.trim() ? g.name : String(g._id);
+        const fallbackName = typeof g.name === "string" && g.name.trim() ? g.name : g._id.toString();
         g.slug = slugify(fallbackName);
         await g.save();
     }
@@ -37,21 +38,21 @@ export async function POST(req: NextRequest, ctx: { params: Promise<{ id: string
     const files = form.getAll("files").filter((f): f is File => f instanceof File);
     if (!files.length) return NextResponse.json({ error: "No files" }, { status: 400 });
 
-    const dir = ensureGalleryDir(g.slug);
+    const galleryName =
+        typeof g.name === "string" && g.name.trim() ? g.name.trim() : g.slug || g._id.toString();
+    const dir = ensureGalleryDir(galleryName, [g.slug, g._id.toString()]);
     const urls: string[] = [];
 
     for (const f of files) {
         const ab = await f.arrayBuffer();
         const buf = Buffer.from(ab);
-        const ext = (extname(f.name) || ".jpg").replace(".", "");
-        const base = basename(f.name, "." + ext);
-        const filename = uniqueName(base, ext);
+        const filename = sanitizeGalleryFileName(f.name);
         const dest = join(dir, filename);
-        await writeBufferFile(dest, buf);
-        urls.push(`/galleries/${g.slug}/${filename}`);
+        await writeBufferFile(dest, buf, { overwrite: true });
+        urls.push(resolveGalleryImageUrl(galleryName, filename));
     }
 
-    g.images.push(...urls);
+    g.images = [...(g.images ?? []).map((img) => resolveGalleryImageUrl(galleryName, img)), ...urls];
     g.updatedAt = new Date();
     await g.save();
 

--- a/src/app/api/family/galleries/route.ts
+++ b/src/app/api/family/galleries/route.ts
@@ -2,12 +2,13 @@
 import { NextRequest, NextResponse } from "next/server";
 import Gallery from "@/models/Gallery";
 import Tag from "@/models/Tag";
-import { ensureGalleryDir, writeBufferFile, uniqueName } from "@/lib/fs-server";
+import { ensureGalleryDir, writeBufferFile } from "@/lib/fs-server";
 import { slugify } from "@/lib/slug";
-import { join, extname, basename } from "node:path";
+import { join } from "node:path";
 import { Types } from "mongoose";
 import { getApprovedFamilyUser } from "@/lib/familyAuth";
 import connect from "@/lib/mongodb";
+import { resolveGalleryImageUrl, sanitizeGalleryFileName } from "@/lib/galleryPaths";
 
 export const runtime = "nodejs";
 
@@ -61,18 +62,16 @@ export async function POST(req: NextRequest) {
         }
 
         const slug = slugify(name);
-        const dir = ensureGalleryDir(slug);
+        const dir = ensureGalleryDir(name);
         const urls: string[] = [];
 
         for (const f of files) {
             const ab = await f.arrayBuffer();
             const buf = Buffer.from(ab);
-            const ext = (extname(f.name) || ".jpg").replace(".", "");
-            const base = basename(f.name, "." + ext);
-            const filename = uniqueName(base, ext);
+            const filename = sanitizeGalleryFileName(f.name);
             const dest = join(dir, filename);
-            await writeBufferFile(dest, buf);
-            urls.push(`/galleries/${slug}/${filename}`);
+            await writeBufferFile(dest, buf, { overwrite: true });
+            urls.push(resolveGalleryImageUrl(name, filename));
         }
 
         const doc = await Gallery.create({

--- a/src/lib/galleryPaths.ts
+++ b/src/lib/galleryPaths.ts
@@ -1,0 +1,47 @@
+export function sanitizeGalleryFileName(originalName: string) {
+    const fallback = `image-${Date.now().toString(36)}`;
+    if (typeof originalName !== "string") {
+        return fallback;
+    }
+    const stripped = originalName.split(/[/\\]/u).pop() ?? "";
+    const trimmed = stripped.trim();
+    const [withoutQuery] = trimmed.split(/[?#]/u);
+    const dotIndex = withoutQuery.lastIndexOf(".");
+    const rawBase = dotIndex > 0 ? withoutQuery.slice(0, dotIndex) : withoutQuery;
+    const rawExt = dotIndex > 0 ? withoutQuery.slice(dotIndex + 1) : "";
+
+    const safeBase = rawBase.replace(/[^a-zA-Z0-9_-]/gu, "_").slice(0, 80) || "image";
+    const safeExt = rawExt.replace(/[^a-zA-Z0-9]/gu, "").slice(0, 12).toLowerCase();
+
+    return safeExt ? `${safeBase}.${safeExt}` : safeBase;
+}
+
+export function resolveGalleryImageUrl(galleryName: string, value: string) {
+    if (!galleryName || typeof galleryName !== "string") return value;
+    const trimmedName = galleryName.trim();
+    if (!trimmedName) return value;
+
+    const basePath = `/galleries/${trimmedName}`;
+
+    if (typeof value !== "string") {
+        return basePath;
+    }
+
+    const trimmedValue = value.trim();
+    if (!trimmedValue) {
+        return basePath;
+    }
+
+    if (/^https?:\/\//iu.test(trimmedValue) || trimmedValue.startsWith("data:")) {
+        return trimmedValue;
+    }
+
+    const galleriesMatch = trimmedValue.match(/^\/galleries\/[^/]+\/(.+)$/u);
+    if (galleriesMatch) {
+        return `${basePath}/${galleriesMatch[1]}`;
+    }
+
+    const filePart = trimmedValue.split(/[/\\]/u).pop() ?? trimmedValue;
+    const safeFile = sanitizeGalleryFileName(filePart);
+    return `${basePath}/${safeFile}`;
+}


### PR DESCRIPTION
## Summary
- add helpers to sanitize gallery filenames and resolve URLs that are keyed off gallery names
- update filesystem utilities and gallery APIs to save uploads under `/galleries/<galleryName>/` and normalize stored image paths
- ensure gallery pages create/rename legacy folders to the name-based layout before rendering images

## Testing
- `npm run lint` *(fails: repository already contains numerous @typescript-eslint/no-explicit-any violations)*
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68d50467e7e48331aae6a6e4aab4c55a