### PR TITLE
Fix gallery upload image map typing

### DIFF
--- a/src/app/api/family/galleries/[id]/upload/route.ts
+++ b/src/app/api/family/galleries/[id]/upload/route.ts
@@ -52,7 +52,10 @@ export async function POST(req: NextRequest, ctx: { params: Promise<{ id: string
         urls.push(resolveGalleryImageUrl(galleryName, filename));
     }
 
-    g.images = [...(g.images ?? []).map((img) => resolveGalleryImageUrl(galleryName, img)), ...urls];
+    g.images = [
+        ...(g.images ?? []).map((img: string) => resolveGalleryImageUrl(galleryName, img)),
+        ...urls,
+    ];
     g.updatedAt = new Date();
     await g.save();
 


### PR DESCRIPTION
## Summary
- annotate gallery image mapping callback to ensure TypeScript infers string values

## Testing
- npm run build *(fails: unable to fetch Google Fonts during next/font download)*

------
https://chatgpt.com/codex/tasks/task_e_68d50b86b1d48331b852372ca83beda7