### PR TITLE
Annotate gallery image mapping parameter

### DIFF
--- a/src/app/api/galleries/[id]/upload/route.ts
+++ b/src/app/api/galleries/[id]/upload/route.ts
@@ -41,7 +41,10 @@ export async function POST(req: NextRequest, ctx: { params: Promise<{ id: string
         urls.push(resolveGalleryImageUrl(galleryName, filename));
     }
 
-    g.images = [...(g.images ?? []).map((img) => resolveGalleryImageUrl(galleryName, img)), ...urls];
+    g.images = [
+        ...(g.images ?? []).map((img: string) => resolveGalleryImageUrl(galleryName, img)),
+        ...urls,
+    ];
     g.updatedAt = new Date();
     await g.save();
 


### PR DESCRIPTION
## Summary
- annotate gallery image mapping parameter to avoid implicit any type
- reformat gallery image assignment for readability

## Testing
- npm run lint *(fails: existing lint errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68d50c58569483318339d93f4bb78307