### PR TITLE
Use gallery slugs for public gallery URLs

### DIFF
--- a/src/app/blog/[id]/page.tsx
+++ b/src/app/blog/[id]/page.tsx
@@ -13,7 +13,7 @@ import type { ReactNode } from "react";
 type Params = Promise<{ id: string }>;
 
 type LeanTag = { _id: Types.ObjectId; name: string; color?: string };
-type LeanGallery = { _id: Types.ObjectId; name: string; images?: string[] };
+type LeanGallery = { _id: Types.ObjectId; slug?: string; name: string; images?: string[] };
 
 type LeanPost = {
     _id: Types.ObjectId;
@@ -79,7 +79,7 @@ export default async function PostPage({ params }: { params: Params }) {
 
     const post = await Post.findById(id)
         .select("title content gallery tags createdAt")
-        .populate("gallery", "name images")
+        .populate("gallery", "name slug images")
         .populate("tags", "name color")
         .lean<LeanPost>();
 
@@ -88,6 +88,8 @@ export default async function PostPage({ params }: { params: Params }) {
     // Normalize gallery
     const gallery = isLeanGallery(post.gallery) ? post.gallery : null;
     const galleryId = gallery?._id?.toString?.();
+    const gallerySlug = typeof gallery?.slug === "string" ? gallery.slug.trim() : "";
+    const galleryPath = gallerySlug ? gallerySlug : galleryId;
     const galleryName = gallery?.name ?? null;
     const galleryImages = Array.isArray(gallery?.images) ? gallery.images : [];
 
@@ -125,8 +127,8 @@ export default async function PostPage({ params }: { params: Params }) {
                         {post.title}
                     </h1>
 
-                    {galleryId && galleryImages.length > 0 && (
-                        <Link href={`/galleries/${galleryId}`} className="mt-2 block">
+                    {galleryPath && galleryImages.length > 0 && (
+                        <Link href={`/galleries/${galleryPath}`} className="mt-2 block">
                             <div className="flex gap-2">
                                 {galleryImages.slice(0, 4).map((src, i) => (
                                     // eslint-disable-next-line @next/next/no-img-element
@@ -144,10 +146,10 @@ export default async function PostPage({ params }: { params: Params }) {
                     <div className="mt-2 flex flex-wrap items-center gap-3 text-xs text-[var(--subt)]">
                         {created && <span className="retro-label">{created}</span>}
 
-                        {galleryId && (
+                        {galleryPath && (
                             <span>
                 <span className="retro-label mr-1">Gallery:</span>
-                <Link href={`/galleries/${galleryId}`} className="text-[var(--accent)] underline">
+                <Link href={`/galleries/${galleryPath}`} className="text-[var(--accent)] underline">
                   {galleryName ?? "View gallery"}
                 </Link>
               </span>

--- a/src/app/family/page.tsx
+++ b/src/app/family/page.tsx
@@ -87,16 +87,18 @@ export default async function FamilyPage({ searchParams }: { searchParams: Searc
 
     const raw = await Gallery.find(
         criteria,
-        { name: 1, images: 1, tags: 1, eventMonth: 1, eventYear: 1, createdAt: 1 }
+        { name: 1, slug: 1, images: 1, tags: 1, eventMonth: 1, eventYear: 1, createdAt: 1 }
     )
         .sort({ eventYear: -1, eventMonth: -1, createdAt: -1 })
         .limit(60)
         .populate("tags", "name color")
-        .lean<{ _id: Types.ObjectId; name: string; images: string[]; eventMonth?: number; eventYear?: number; tags?: (Types.ObjectId | LeanTag)[] }[]>();
+        .lean<{ _id: Types.ObjectId; slug?: string; name: string; images: string[]; eventMonth?: number; eventYear?: number; tags?: (Types.ObjectId | LeanTag)[] }[]>();
 
     const cards = raw.map((g) => {
         const id = g._id.toString();
         const thumb = Array.isArray(g.images) && g.images.length > 0 ? g.images[0] : "";
+        const rawSlug = typeof g.slug === "string" ? g.slug.trim() : "";
+        const slug = rawSlug ? rawSlug : undefined;
 
         // Narrow tags safely (ObjectId vs populated)
         const tags =
@@ -110,9 +112,10 @@ export default async function FamilyPage({ searchParams }: { searchParams: Searc
 
         return {
             id,
+            slug,
             name: g.name ?? "(untitled)",
             thumb,
-            href: `/galleries/${id}`,
+            href: `/galleries/${slug ?? id}`,
             m: g.eventMonth,
             y: g.eventYear,
             tags,

--- a/src/app/galleries/page.tsx
+++ b/src/app/galleries/page.tsx
@@ -12,6 +12,7 @@ type LeanTag = { _id: Types.ObjectId; name: string; color?: string };
 
 type LeanGalleryCard = {
     _id: Types.ObjectId;
+    slug?: string;
     name: string;
     images: string[];
     eventMonth?: number;
@@ -85,7 +86,7 @@ export default async function GalleriesIndex({ searchParams }: { searchParams: S
     // Query galleries (NOTE the awaited find + typed lean)
     const raw = await Gallery.find(
         criteria,
-        { name: 1, images: 1, tags: 1, eventMonth: 1, eventYear: 1, createdAt: 1 }
+        { name: 1, slug: 1, images: 1, tags: 1, eventMonth: 1, eventYear: 1, createdAt: 1 }
     )
         .sort({ eventYear: -1, eventMonth: -1, createdAt: -1 })
         .limit(60)
@@ -95,6 +96,7 @@ export default async function GalleriesIndex({ searchParams }: { searchParams: S
     const cards = raw.map((g) => {
         const id = g._id.toString();
         const thumb = Array.isArray(g.images) && g.images.length > 0 ? g.images[0] : "";
+        const slug = typeof g.slug === "string" && g.slug.trim() ? g.slug.trim() : undefined;
         const tags = (g.tags ?? []).map((t) => ({
             id: t._id.toString(),
             name: t.name,
@@ -102,9 +104,10 @@ export default async function GalleriesIndex({ searchParams }: { searchParams: S
         }));
         return {
             id,
+            slug,
             name: g.name ?? "(untitled)",
             thumb,
-            href: `/galleries/${id}`,
+            href: `/galleries/${slug ?? id}`,
             m: g.eventMonth,
             y: g.eventYear,
             tags,


### PR DESCRIPTION
## Summary
- change the public gallery route to use slug-based URLs while still accepting legacy ID links
- load gallery slugs in the public, family, and blog views so that outgoing links point at the slug paths
- keep legacy directory resolution by recording both slug and ID keys when ensuring gallery folders

## Testing
- npm run lint *(fails: existing `@typescript-eslint/no-explicit-any` violations in unrelated files)*
- npm test


------
https://chatgpt.com/codex/tasks/task_e_68d50da4b1e88331bb4cd07eaeebdc5a