### PR TITLE
Fix gallery query typing

### DIFF
--- a/src/app/galleries/[slug]/page.tsx
+++ b/src/app/galleries/[slug]/page.tsx
@@ -46,13 +46,13 @@ function buildGalleryQuery(slugOrId: string) {
                     { slug: trimmed },
                     { _id: new Types.ObjectId(trimmed) },
                 ],
-            } as const;
+            };
         } catch {
             // fall through to slug lookup if ObjectId construction fails
         }
     }
 
-    return { slug: trimmed } as const;
+    return { slug: trimmed };
 }
 
 export default async function GalleryPage({ params }: { params: Params }) {


### PR DESCRIPTION
## Summary
- update the gallery query builder to return mutable query objects so mongoose accepts the filter

## Testing
- npm run build *(fails: next/font could not fetch Google fonts in the CI environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d510c2d60c83319ae0a5a8c63c2f29