### PR TITLE
Refactor gallery assets to uploads directory

### DIFF
--- a/src/app/api/galleries/[id]/route.ts
+++ b/src/app/api/galleries/[id]/route.ts
@@ -101,7 +101,9 @@ export async function DELETE(req: NextRequest, ctx: { params: Promise<{ id: stri
             (key): key is string => typeof key === "string" && key.trim() !== ""
         );
         for (const key of possibleKeys) {
-            tryDirs.add(join(PUBLIC_DIR, "galleries", key.trim()));
+            const trimmed = key.trim();
+            tryDirs.add(join(PUBLIC_DIR, "uploads", trimmed));
+            tryDirs.add(join(PUBLIC_DIR, "galleries", trimmed));
         }
 
         // 2) Any dirs derivable from stored URLs (covers legacy paths or typos)

--- a/src/app/family/page.tsx
+++ b/src/app/family/page.tsx
@@ -6,6 +6,7 @@ import { Card } from "@/components/ui/Card";
 import FamilyLogin from "@/components/FamilyLogin";
 import { Types } from "mongoose";
 import { getApprovedFamilyUser } from "@/lib/familyAuth";
+import { resolveGalleryImageUrl } from "@/lib/galleryPaths";
 
 export const dynamic = "force-dynamic";
 
@@ -96,9 +97,14 @@ export default async function FamilyPage({ searchParams }: { searchParams: Searc
 
     const cards = raw.map((g) => {
         const id = g._id.toString();
-        const thumb = Array.isArray(g.images) && g.images.length > 0 ? g.images[0] : "";
         const rawSlug = typeof g.slug === "string" ? g.slug.trim() : "";
         const slug = rawSlug ? rawSlug : undefined;
+        const galleryName =
+            typeof g.name === "string" && g.name.trim()
+                ? g.name.trim()
+                : slug || id;
+        const rawThumb = Array.isArray(g.images) && g.images.length > 0 ? g.images[0] : "";
+        const thumb = rawThumb ? resolveGalleryImageUrl(galleryName, rawThumb) : "";
 
         // Narrow tags safely (ObjectId vs populated)
         const tags =

--- a/src/app/galleries/page.tsx
+++ b/src/app/galleries/page.tsx
@@ -6,6 +6,7 @@ import Tag from "@/models/Tag";
 import { Card } from "@/components/ui/Card";
 import { Types } from "mongoose";
 import TagFilterDropdown from "@/components/TagFilterDropdown";
+import { resolveGalleryImageUrl } from "@/lib/galleryPaths";
 
 type SearchParams = Promise<Record<string, string | string[] | undefined>>;
 type LeanTag = { _id: Types.ObjectId; name: string; color?: string };
@@ -95,8 +96,13 @@ export default async function GalleriesIndex({ searchParams }: { searchParams: S
 
     const cards = raw.map((g) => {
         const id = g._id.toString();
-        const thumb = Array.isArray(g.images) && g.images.length > 0 ? g.images[0] : "";
         const slug = typeof g.slug === "string" && g.slug.trim() ? g.slug.trim() : undefined;
+        const galleryName =
+            typeof g.name === "string" && g.name.trim()
+                ? g.name.trim()
+                : slug || id;
+        const rawThumb = Array.isArray(g.images) && g.images.length > 0 ? g.images[0] : "";
+        const thumb = rawThumb ? resolveGalleryImageUrl(galleryName, rawThumb) : "";
         const tags = (g.tags ?? []).map((t) => ({
             id: t._id.toString(),
             name: t.name,

--- a/src/lib/galleryPaths.ts
+++ b/src/lib/galleryPaths.ts
@@ -21,7 +21,7 @@ export function resolveGalleryImageUrl(galleryName: string, value: string) {
     const trimmedName = galleryName.trim();
     if (!trimmedName) return value;
 
-    const basePath = `/galleries/${trimmedName}`;
+    const basePath = `/uploads/${trimmedName}`;
 
     if (typeof value !== "string") {
         return basePath;
@@ -36,9 +36,9 @@ export function resolveGalleryImageUrl(galleryName: string, value: string) {
         return trimmedValue;
     }
 
-    const galleriesMatch = trimmedValue.match(/^\/galleries\/[^/]+\/(.+)$/u);
-    if (galleriesMatch) {
-        return `${basePath}/${galleriesMatch[1]}`;
+    const uploadsMatch = trimmedValue.match(/^\/(?:uploads|galleries)\/[^/]+\/(.+)$/u);
+    if (uploadsMatch) {
+        return `${basePath}/${uploadsMatch[1]}`;
     }
 
     const filePart = trimmedValue.split(/[/\\]/u).pop() ?? trimmedValue;


### PR DESCRIPTION
## Summary
- move gallery filesystem helpers to store media under /uploads and migrate legacy folders
- normalize API responses and thumbnail rendering to emit /uploads-based image URLs
- expand gallery cleanup to look for both /uploads and legacy /galleries directories when deleting files

## Testing
- npm run lint *(fails: existing @typescript-eslint/no-explicit-any violations in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68d51e1b2dac833189d25469f8bd6d03